### PR TITLE
Packageバッチ、サイレント実行モードを追加

### DIFF
--- a/iplass-tools-batch/src/main/bat/start_package_import.bat
+++ b/iplass-tools-batch/src/main/bat/start_package_import.bat
@@ -19,6 +19,9 @@ set EXEC_MODE=WIZARD
 REM Tenant Id (if value is -1, specified by wizard or silent package config)
 set TENANT_ID=-1
 
+REM import file (if value is 'empty', specified by wizard or silent package config)
+set FILE=empty
+
 REM if silent mode, package export config file name (please set your package-imp-config file)
 set PACK_CONFIG=./../conf/pack-imp-config.properties
 
@@ -30,7 +33,7 @@ REM APP class
 set EXEC_APP=org.iplass.mtp.tools.batch.pack.PackageImport
 
 REM App Arguments
-set APP_ARGS=%EXEC_MODE% %TENANT_ID% %LANG%
+set APP_ARGS=%EXEC_MODE% %TENANT_ID% %FILE% %LANG%
 
 REM Silent mode package config
 set PACK_CONFIG_ARG=pack.config=%PACK_CONFIG%

--- a/iplass-tools-batch/src/main/bat/start_package_import.bat
+++ b/iplass-tools-batch/src/main/bat/start_package_import.bat
@@ -13,10 +13,14 @@ REM app arguments
 REM (Depend on the situation, please change values)
 REM ----------------------------------------------------
 
-REM Execute Mode
+REM Execute Mode (WIZARD or SILENT)
 set EXEC_MODE=WIZARD
 
+REM Tenant Id (if value is -1, specified by wizard or silent package config)
+set TENANT_ID=-1
 
+REM if silent mode, package export config file name (please set your package-imp-config file)
+set PACK_CONFIG=./../conf/pack-imp-config.properties
 
 REM ----------------------------------------------------
 REM app settings
@@ -26,7 +30,10 @@ REM APP class
 set EXEC_APP=org.iplass.mtp.tools.batch.pack.PackageImport
 
 REM App Arguments
-set APP_ARGS=%EXEC_MODE% %LANG%
+set APP_ARGS=%EXEC_MODE% %TENANT_ID% %LANG%
+
+REM Silent mode package config
+set PACK_CONFIG_ARG=pack.config=%PACK_CONFIG%
 
 REM ----------------------------------------------------
 REM confirm
@@ -39,13 +46,21 @@ echo EXEC_CLASS_PATH : %EXEC_CLASS_PATH%
 echo SYS_ENV         : %SYS_ENV%
 echo
 
+if "%EXEC_MODE%" == "SILENT" goto EXECUTE
+
 pause
 
 REM ----------------------------------------------------
 REM execute
 REM ----------------------------------------------------
 
+:EXECUTE
+
 REM execute tool
-java -cp %EXEC_CLASS_PATH% -D%SYS_ENV% %EXEC_APP% %APP_ARGS%
+java -cp %EXEC_CLASS_PATH% -D%SYS_ENV% -D%PACK_CONFIG_ARG% %EXEC_APP% %APP_ARGS%
+
+if "%EXEC_MODE%" == "SILENT" goto END
 
 pause
+
+:END

--- a/iplass-tools-batch/src/main/conf/pack-imp-config.properties
+++ b/iplass-tools-batch/src/main/conf/pack-imp-config.properties
@@ -1,0 +1,43 @@
+#---------------------
+#テナントの設定
+#テナントはバッチの引数でIDを指定するか、プロパティファイルでURLまたはIDを指定してください。
+#バッチ引数での指定が優先されます。
+#---------------------
+
+#対象のテナントURL(またはテナント名)
+tenantUrl=
+#対象のテナントID
+tenantId=
+
+#---------------------
+#入力設定
+#---------------------
+
+#パッケージファイル(パスを含めて指定)
+importFile=
+#作業用ディレクトリ
+workDir=
+
+#---------------------
+#Entityデータ登録設定
+#---------------------
+
+#EntityデータをTruncateするか(true or false)
+entity.truncate=false
+#Listnerを実行(true or false)
+entity.notifyListener=false
+#Validationを実行する(更新不可項目を対象にする場合はfalseに強制設定)(true or false)
+entity.withValidation=false
+#更新不可項目を更新対象にする(true or false)
+entity.updateDisupdatableProperty=false
+#Entityデータを強制更新するか(true or false)
+entity.forceUpdate=false
+#エラーデータはSkipして継続するか(true or false)
+entity.errorSkip=false
+#存在しないプロパティは無視(true or false)
+entity.ignoreInvalidProperty=false
+#OIDに付与するPrefix
+entity.prefixOid=
+#Commit単位(件数)
+entity.commitLimit=
+

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageExport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageExport.java
@@ -183,16 +183,15 @@ public class PackageExport extends MtpCuiBase {
 	 * @param param Export情報
 	 * @return
 	 */
-	public boolean export(final PackageExportParameter param) {
+	public boolean exportPack(final PackageExportParameter param) {
 
 		setSuccess(false);
 
 		try {
 			boolean isSuccess = Transaction.required(t -> {
 
-				TenantContext tContext = tcs.getTenantContext(param.getTenantId());
-
-				return ExecuteContext.executeAs(tContext, () -> {
+				TenantContext tc = tcs.getTenantContext(param.getTenantId());
+				return ExecuteContext.executeAs(tc, () -> {
 					ExecuteContext.getCurrentContext().setLanguage(getLanguage());
 
 					//外部から直接呼び出された場合を考慮し、Pathを取得
@@ -601,8 +600,8 @@ public class PackageExport extends MtpCuiBase {
 
 		PackageExportParameter param = new PackageExportParameter(tenant.getId(), tenant.getName());
 
-		TenantContext tContext = tcs.getTenantContext(param.getTenantId());
-		return ExecuteContext.executeAs(tContext, ()-> {
+		TenantContext tc = tcs.getTenantContext(param.getTenantId());
+		return ExecuteContext.executeAs(tc, ()-> {
 			ExecuteContext.getCurrentContext().setLanguage(getLanguage());
 
 			//出力先ディレクトリ
@@ -781,7 +780,7 @@ public class PackageExport extends MtpCuiBase {
 
 			//Export処理実行
 			try {
-				export(param);
+				exportPack(param);
 
 				return isSuccess();
 
@@ -875,8 +874,8 @@ public class PackageExport extends MtpCuiBase {
 
 		PackageExportParameter param = new PackageExportParameter(tenant.getId(), tenant.getName());
 
-		TenantContext tContext = tcs.getTenantContext(param.getTenantId());
-		return ExecuteContext.executeAs(tContext, ()-> {
+		TenantContext tc = tcs.getTenantContext(param.getTenantId());
+		return ExecuteContext.executeAs(tc, ()-> {
 			ExecuteContext.getCurrentContext().setLanguage(getLanguage());
 
 			String exportDirName = prop.getProperty(PROP_EXPORT_DIR);
@@ -956,9 +955,7 @@ public class PackageExport extends MtpCuiBase {
 			logArguments(param);
 
 			//Export処理実行
-			boolean ret = export(param);
-
-			return ret;
+			return exportPack(param);
 		});
 
 	}

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageImportParameter.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageImportParameter.java
@@ -13,6 +13,35 @@ import org.iplass.mtp.tenant.Tenant;
 
 public class PackageImportParameter {
 
+	/** Silentモード テナントURL */
+	public static final String PROP_TENANT_URL = "tenantUrl";
+	/** Silentモード テナントID */
+	public static final String PROP_TENANT_ID = "tenantId";
+
+	/** Silentモード パッケージファイル */
+	public static final String PROP_IMPORT_FILE = "importFile";
+	/** Silentモード 作業用ディレクトリ */
+	public static final String PROP_WORK_DIR = "workDir";
+
+	/** Silentモード Entityデータ Truncate */
+	public static final String PROP_ENTITY_TRUNCATE = "entity.truncate";
+	/** Silentモード Entityデータ Listnerを実行 */
+	public static final String PROP_ENTITY_NOTIFY_LISTENER = "entity.notifyListener";
+	/** Silentモード Entityデータ Validationを実行(更新不可項目を対象にする場合はfalseに強制設定) */
+	public static final String PROP_ENTITY_WITH_VALIDATION = "entity.withValidation";
+	/** Silentモード Entityデータ 更新不可項目を更新対象 */
+	public static final String PROP_ENTITY_UPDATE_DISUPDATABLE = "entity.updateDisupdatableProperty";
+	/** Silentモード Entityデータ 強制更新 */
+	public static final String PROP_ENTITY_FORCE_UPDATE = "entity.forceUpdate";
+	/** Silentモード Entityデータ エラーデータはSkip */
+	public static final String PROP_ENTITY_ERROR_SKIP = "entity.errorSkip";
+	/** Silentモード Entityデータ 存在しないプロパティは無視 */
+	public static final String PROP_ENTITY_IGNORE_INVALID_PROPERTY = "entity.ignoreInvalidProperty";
+	/** Silentモード Entityデータ OIDに付与するPrefix */
+	public static final String PROP_ENTITY_PREFIX_OID = "entity.prefixOid";
+	/** Silentモード Entityデータ Commit単位(件数) */
+	public static final String PROP_ENTITY_COMMIT_LIMIT = "entity.commitLimit";
+
 	// テナントID
 	private int tenantId;
 

--- a/iplass-tools-batch/src/main/resources/mtp-tools-batch-messages.properties
+++ b/iplass-tools-batch/src/main/resources/mtp-tools-batch-messages.properties
@@ -109,6 +109,8 @@ PackageExport.notFoundMetaLog                    = Match the [{0}] metadata is n
 PackageExport.notFoundPackageInfoLog             = Can not get Package information. : oid = {0}
 PackageExport.startExportPackageLog              = Start creating the Package.
 
+PackageImport.Silent.notExistsConfigFileMsg               = package config file does not exist. path={0}
+PackageImport.Silent.requiredConfigFileMsg                = config file path is required. key={0}
 PackageImport.Wizard.confirmForceUpdateMsg                = Even when there is no change, does it update compulsorily?
 PackageImport.Wizard.confirmIgnoreNotExistsPropertyMsg    = Do you want to continue the Import property that does not exist will ignore?
 PackageImport.Wizard.confirmImportPackageMsg              = Do you want to import the Package with the contents of the above?
@@ -120,33 +122,33 @@ PackageImport.Wizard.confirmSkipErrorDataMsg              = Do you want to conti
 PackageImport.Wizard.confirmTrancateDataMsg               = Do you want to delete all the existing data?
 PackageImport.Wizard.confirmUpdateDisupdatablePropertyMsg = Do you want to update the update disabled properties?
 PackageImport.Wizard.confirmWithValidationMsg             = Do you want to run the Validation?
-PackageImport.Wizard.createdWorkDirMsg                    = Created a directory. : dir = {0}
-PackageImport.Wizard.errorAnalysisFileMsg                 = An error has occurred in the analysis of the import file. : {0}
-PackageImport.Wizard.includeWarnTenantMetaMsg             = Tenant data of warning is included. Skip because they do not import this data in a batch process.
 PackageImport.Wizard.inputCommitUnitMsg                   = Input the commit unit.
 PackageImport.Wizard.inputImportFileMsg                   = Input the import file path.
 PackageImport.Wizard.inputLocaleMsg                       = Input the Locale of import file.
 PackageImport.Wizard.inputOIDPrefixMsg                    = Input the OID prefix.
 PackageImport.Wizard.inputTimezoneMsg                     = Input the TimeZone of import file.
 PackageImport.Wizard.inputWorkMsg                         = Input the work directory.
-PackageImport.Wizard.notDirMsg                            = [{0}] is not a directory.
-PackageImport.Wizard.notExistsImportFileMsg               = Import file does not exist.
 PackageImport.Wizard.notIncludeEntityMsg                  = Target entity is zero.
 PackageImport.Wizard.notIncludeMetaMsg                    = Target metadata is zero.
 PackageImport.Wizard.requiredImportFilePathMsg            = Import file path is required.
-PackageImport.Wizard.warnOIDPrefixMsg                     = Please enter only alphanumeric OID prefix.
 PackageImport.completedImportEntityDataLog                = Complete. [{0}] : ins({1}),upd({2}),err({3})
 PackageImport.completedImportEntityLog                    = The import of the Entity data is complete.
 PackageImport.completedImportMetaLog                      = The import of the metadata is complete.
 PackageImport.completedImportPackageLog                   = Completed a Package import. : file = {0}
 PackageImport.continueLog                                 = Continue the process.
+PackageImport.createdDirMsg                               = Created a directory. : dir = {0}
 PackageImport.createdPackageInfoLog                       = Registered the Package information. : oid = {0}
+PackageImport.errorAnalysisFileMsg                        = An error has occurred in the analysis of the import file. : {0}
 PackageImport.errorImportEntityDataLog                    = Error. [{0}]
+PackageImport.includeWarnTenantMetaMsg                    = Tenant data of warning is included. Skip because they do not import this data in a batch process.
+PackageImport.notDirMsg                                   = [{0}] is not a directory.
+PackageImport.notExistsImportFileMsg                      = Import file does not exist.
 PackageImport.notIncludeEntityLog                         = Entity data is not included.
 PackageImport.notIncludeMetaLog                           = Metadata is not included.
 PackageImport.startImportEntityDataLog                    = Start. [{0}]
 PackageImport.startImportEntityLog                        = Start the import of Entity data.
 PackageImport.startImportMetaLog                          = Start the import of metadata.
+PackageImport.warnOIDPrefixMsg                            = Please enter only alphanumeric OID prefix.
 
 SqlServerPartitionManager.Create.createdPartitionMsg = Created a Partition. : id = {0}
 

--- a/iplass-tools-batch/src/main/resources/mtp-tools-batch-messages_en.properties
+++ b/iplass-tools-batch/src/main/resources/mtp-tools-batch-messages_en.properties
@@ -109,6 +109,8 @@ PackageExport.notFoundMetaLog                    = Match the [{0}] metadata is n
 PackageExport.notFoundPackageInfoLog             = Can not get Package information. : oid = {0}
 PackageExport.startExportPackageLog              = Start creating the Package.
 
+PackageImport.Silent.notExistsConfigFileMsg               = package config file does not exist. path={0}
+PackageImport.Silent.requiredConfigFileMsg                = config file path is required. key={0}
 PackageImport.Wizard.confirmForceUpdateMsg                = Even when there is no change, does it update compulsorily?
 PackageImport.Wizard.confirmIgnoreNotExistsPropertyMsg    = Do you want to continue the Import property that does not exist will ignore?
 PackageImport.Wizard.confirmImportPackageMsg              = Do you want to import the Package with the contents of the above?
@@ -120,33 +122,33 @@ PackageImport.Wizard.confirmSkipErrorDataMsg              = Do you want to conti
 PackageImport.Wizard.confirmTrancateDataMsg               = Do you want to delete all the existing data?
 PackageImport.Wizard.confirmUpdateDisupdatablePropertyMsg = Do you want to update the update disabled properties?
 PackageImport.Wizard.confirmWithValidationMsg             = Do you want to run the Validation?
-PackageImport.Wizard.createdWorkDirMsg                    = Created a directory. : dir = {0}
-PackageImport.Wizard.errorAnalysisFileMsg                 = An error has occurred in the analysis of the import file. : {0}
-PackageImport.Wizard.includeWarnTenantMetaMsg             = Tenant data of warning is included. Skip because they do not import this data in a batch process.
 PackageImport.Wizard.inputCommitUnitMsg                   = Input the commit unit.
 PackageImport.Wizard.inputImportFileMsg                   = Input the import file path.
 PackageImport.Wizard.inputLocaleMsg                       = Input the Locale of import file.
 PackageImport.Wizard.inputOIDPrefixMsg                    = Input the OID prefix.
 PackageImport.Wizard.inputTimezoneMsg                     = Input the TimeZone of import file.
 PackageImport.Wizard.inputWorkMsg                         = Input the work directory.
-PackageImport.Wizard.notDirMsg                            = [{0}] is not a directory.
-PackageImport.Wizard.notExistsImportFileMsg               = Import file does not exist.
 PackageImport.Wizard.notIncludeEntityMsg                  = Target entity is zero.
 PackageImport.Wizard.notIncludeMetaMsg                    = Target metadata is zero.
 PackageImport.Wizard.requiredImportFilePathMsg            = Import file path is required.
-PackageImport.Wizard.warnOIDPrefixMsg                     = Please enter only alphanumeric OID prefix.
 PackageImport.completedImportEntityDataLog                = Complete. [{0}] : ins({1}),upd({2}),err({3})
 PackageImport.completedImportEntityLog                    = The import of the Entity data is complete.
 PackageImport.completedImportMetaLog                      = The import of the metadata is complete.
 PackageImport.completedImportPackageLog                   = Completed a Package import. : file = {0}
 PackageImport.continueLog                                 = Continue the process.
+PackageImport.createdDirMsg                               = Created a directory. : dir = {0}
 PackageImport.createdPackageInfoLog                       = Registered the Package information. : oid = {0}
+PackageImport.errorAnalysisFileMsg                        = An error has occurred in the analysis of the import file. : {0}
 PackageImport.errorImportEntityDataLog                    = Error. [{0}]
+PackageImport.includeWarnTenantMetaMsg                    = Tenant data of warning is included. Skip because they do not import this data in a batch process.
+PackageImport.notDirMsg                                   = [{0}] is not a directory.
+PackageImport.notExistsImportFileMsg                      = Import file does not exist.
 PackageImport.notIncludeEntityLog                         = Entity data is not included.
 PackageImport.notIncludeMetaLog                           = Metadata is not included.
 PackageImport.startImportEntityDataLog                    = Start. [{0}]
 PackageImport.startImportEntityLog                        = Start the import of Entity data.
 PackageImport.startImportMetaLog                          = Start the import of metadata.
+PackageImport.warnOIDPrefixMsg                            = Please enter only alphanumeric OID prefix.
 
 SqlServerPartitionManager.Create.createdPartitionMsg = Created a Partition. : id = {0}
 

--- a/iplass-tools-batch/src/main/resources/mtp-tools-batch-messages_ja.properties
+++ b/iplass-tools-batch/src/main/resources/mtp-tools-batch-messages_ja.properties
@@ -109,6 +109,8 @@ PackageExport.notFoundMetaLog                    = {0} に該当するメタデ�
 PackageExport.notFoundPackageInfoLog             = Package情報が取得できません。 : oid = {0}
 PackageExport.startExportPackageLog              = Packageの作成を開始します。
 
+PackageImport.Silent.notExistsConfigFileMsg               = Package設定ファイルが存在しません。path={0}
+PackageImport.Silent.requiredConfigFileMsg                = Package設定ファイルのパスは必須です。key={0}
 PackageImport.Wizard.confirmForceUpdateMsg                = 変更がない場合も強制的に更新しますか？
 PackageImport.Wizard.confirmIgnoreNotExistsPropertyMsg    = 存在しないプロパティは無視してImportを続けますか？
 PackageImport.Wizard.confirmImportPackageMsg              = 上記の内容でImportしてよろしいですか？
@@ -120,33 +122,33 @@ PackageImport.Wizard.confirmSkipErrorDataMsg              = エラーデータ�
 PackageImport.Wizard.confirmTrancateDataMsg               = 既存データを全て削除しますか？
 PackageImport.Wizard.confirmUpdateDisupdatablePropertyMsg = 更新不可項目を更新しますか？
 PackageImport.Wizard.confirmWithValidationMsg             = Validation処理を実行しますか？
-PackageImport.Wizard.createdWorkDirMsg                    = ディレクトリを作成しました。 : dir = {0}
-PackageImport.Wizard.errorAnalysisFileMsg                 = 指定されたファイルの解析でエラーが発生しました。 : {0}
-PackageImport.Wizard.includeWarnTenantMetaMsg             = 警告のテナントデータが含まれています。バッチ処理ではこのデータを取り込めないためスキップします。
 PackageImport.Wizard.inputCommitUnitMsg                   = コミット単位を入力してください。
 PackageImport.Wizard.inputImportFileMsg                   = Importファイルパスを入力してください。
 PackageImport.Wizard.inputLocaleMsg                       = ImportファイルのLocaleを入力してください。
 PackageImport.Wizard.inputOIDPrefixMsg                    = OID Prefixを入力してください。
 PackageImport.Wizard.inputTimezoneMsg                     = ImportファイルのTimeZoneを入力してください。
 PackageImport.Wizard.inputWorkMsg                         = 作業用ディレクトリを入力してください。
-PackageImport.Wizard.notDirMsg                            = [{0}] はディレクトリではありません。
-PackageImport.Wizard.notExistsImportFileMsg               = Importファイルが存在しません。
 PackageImport.Wizard.notIncludeEntityMsg                  = 対象Entityは 0 件です。
 PackageImport.Wizard.notIncludeMetaMsg                    = 対象メタデータは 0 件です。
 PackageImport.Wizard.requiredImportFilePathMsg            = Importファイルパスは必須です。
-PackageImport.Wizard.warnOIDPrefixMsg                     = OID Prefixは英数字のみで入力してください。
 PackageImport.completedImportEntityDataLog                = [{0}] データのImportが完了しました。 : ins({1}),upd({2}),err({3})
 PackageImport.completedImportEntityLog                    = EntityデータのImportが完了しました。
 PackageImport.completedImportMetaLog                      = メタデータのImportが完了しました。
 PackageImport.completedImportPackageLog                   = PackageのImportが完了しました。 : file = {0}
 PackageImport.continueLog                                 = このまま処理を継続します。
+PackageImport.createdDirMsg                               = ディレクトリを作成しました。 : dir = {0}
 PackageImport.createdPackageInfoLog                       = Package情報を登録しました。 : oid = {0}
+PackageImport.errorAnalysisFileMsg                        = 指定されたファイルの解析でエラーが発生しました。 : {0}
 PackageImport.errorImportEntityDataLog                    = [{0}] データのImportでエラーが発生しました。
+PackageImport.includeWarnTenantMetaMsg                    = 警告のテナントデータが含まれています。バッチ処理ではこのデータを取り込めないためスキップします。
+PackageImport.notDirMsg                                   = [{0}] はディレクトリではありません。
+PackageImport.notExistsImportFileMsg                      = Importファイルが存在しません。
 PackageImport.notIncludeEntityLog                         = Entityデータは含まれていません。
 PackageImport.notIncludeMetaLog                           = メタデータは含まれていません。
 PackageImport.startImportEntityDataLog                    = [{0}] データのImportを開始します。
 PackageImport.startImportEntityLog                        = EntityデータのImportを開始します。
 PackageImport.startImportMetaLog                          = メタデータのImportを開始します。
+PackageImport.warnOIDPrefixMsg                            = OID Prefixは英数字のみで入力してください。
 
 SqlServerPartitionManager.Create.createdPartitionMsg = Partitionを作成しました。 : id = {0}
 

--- a/iplass-tools-batch/src/main/sh/start_package_import.sh
+++ b/iplass-tools-batch/src/main/sh/start_package_import.sh
@@ -16,6 +16,9 @@ export EXEC_MODE=WIZARD
 # Tenant Id (if value is -1, specified by wizard or silent package config)
 export TENANT_ID=-1
 
+# import file (if value is 'empty', specified by wizard or silent package config)
+export FILE=empty
+
 # if silent mode, package import config file name (please set your package-imp-config file)
 export PACK_CONFIG=./../conf/pack-imp-config.properties
 
@@ -27,7 +30,7 @@ export PACK_CONFIG=./../conf/pack-imp-config.properties
 export EXEC_APP=org.iplass.mtp.tools.batch.pack.PackageImport
 
 # App Arguments
-export APP_ARGS="${EXEC_MODE} ${TENANT_ID} ${LANG}"
+export APP_ARGS="${EXEC_MODE} ${TENANT_ID} ${FILE} ${LANG}"
 
 # Silent mode package config
 export PACK_CONFIG_ARG=pack.config=${PACK_CONFIG}

--- a/iplass-tools-batch/src/main/sh/start_package_import.sh
+++ b/iplass-tools-batch/src/main/sh/start_package_import.sh
@@ -10,10 +10,14 @@
 # (Depend on the situation, please change values)
 # ----------------------------------------------------
 
-# Execute Mode
+# Execute Mode (WIZARD or SILENT)
 export EXEC_MODE=WIZARD
 
+# Tenant Id (if value is -1, specified by wizard or silent package config)
+export TENANT_ID=-1
 
+# if silent mode, package import config file name (please set your package-imp-config file)
+export PACK_CONFIG=./../conf/pack-imp-config.properties
 
 # ----------------------------------------------------
 # app settings
@@ -23,7 +27,10 @@ export EXEC_MODE=WIZARD
 export EXEC_APP=org.iplass.mtp.tools.batch.pack.PackageImport
 
 # App Arguments
-export APP_ARGS="${EXEC_MODE} ${LANG}"
+export APP_ARGS="${EXEC_MODE} ${TENANT_ID} ${LANG}"
+
+# Silent mode package config
+export PACK_CONFIG_ARG=pack.config=${PACK_CONFIG}
 
 # ----------------------------------------------------
 # confirm
@@ -34,20 +41,27 @@ echo execute ${EXEC_APP}. config file is ${SERVICE_CONFIG_NAME}.
 echo
 echo EXEC_CLASS_PATH : ${EXEC_CLASS_PATH}
 echo SYS_ENV         : ${SYS_ENV}
+
+if [ "${EXEC_MODE}" = "WIZARD" ]
+then
 echo
 echo "Please press any key..."
 
 #wait
 read wait
+fi
 
 # ----------------------------------------------------
 # execute
 # ----------------------------------------------------
 
 # execute tool
-java -cp ${EXEC_CLASS_PATH} -D${SYS_ENV} ${EXEC_APP} ${APP_ARGS}
+java -cp ${EXEC_CLASS_PATH} -D${SYS_ENV} -D${PACK_CONFIG_ARG} ${EXEC_APP} ${APP_ARGS}
 
+if [ "${EXEC_MODE}" = "WIZARD" ]
+then
 echo "Please press any key..."
 
 #wait
 read wait
+fi


### PR DESCRIPTION
Packageバッチ、サイレント実行モードを追加 #3。

現状、ウィザード形式でしか実行できないが、バックアップなどの利用用途のために
サイレントモードでの実行を可能にする。

入力パラメータについては、パラメータ数が多いため、propertyファイルとして別途指定する方式で提供。
