### PR TITLE
全文検索、Luceneでユーザ定義辞書を追加できるようにする #6

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/AnalyzerFactory.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/AnalyzerFactory.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2012 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.iplass.mtp.impl.fulltextsearch;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.Charset;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.StopwordAnalyzerBase;
+import org.apache.lucene.analysis.ja.JapaneseAnalyzer;
+import org.apache.lucene.analysis.ja.JapaneseTokenizer.Mode;
+import org.apache.lucene.analysis.ja.dict.UserDictionary;
+import org.iplass.mtp.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AnalyzerFactory {
+
+	private static Logger logger = LoggerFactory.getLogger(AnalyzerFactory.class);
+
+	public static Analyzer createAnalyzer(String className, AnalyzerSetting analyzerSetting)
+			throws ClassNotFoundException, SecurityException, InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException {
+		if (analyzerSetting != null && JapaneseAnalyzer.class.isAssignableFrom(Class.forName(className))) {
+			UserDictionary userDict = AnalyzerFactoryJapaneseAnalyzer.createUserDictionary(analyzerSetting.getUserDictionary());
+			Mode mode = AnalyzerFactoryJapaneseAnalyzer.createMode(analyzerSetting.getMode());
+			CharArraySet stopwords = AnalyzerFactoryJapaneseAnalyzer.createStopwords(analyzerSetting.getStopwords());
+			Set<String> stoptags = AnalyzerFactoryJapaneseAnalyzer.createStopTags(analyzerSetting.getStoptags());
+			try {
+				Constructor<?> c = Class.forName(className).getConstructor(UserDictionary.class, Mode.class, CharArraySet.class, Set.class);
+				return (Analyzer) c.newInstance(userDict, mode, stopwords, stoptags);
+			} catch (NoSuchMethodException e) {
+			}
+		}
+		return (Analyzer) Class.forName(className).getConstructor().newInstance();
+	}
+
+	private static abstract class AnalyzerFactoryJapaneseAnalyzer extends StopwordAnalyzerBase {
+
+		public static UserDictionary createUserDictionary(String userDictionary) {
+			if (StringUtil.isEmpty(userDictionary)) {
+				return null;
+			}
+
+			InputStreamReader reader = null;
+			try {
+				reader = new InputStreamReader(AnalyzerFactoryJapaneseAnalyzer.class.getResourceAsStream(userDictionary), Charset.forName("utf-8"));
+				return UserDictionary.open(reader);
+			} catch (IOException e) {
+				logger.warn("User Dictionary not found. : " + userDictionary);
+			} finally {
+				try {
+					if (reader != null) {
+						reader.close();
+					}
+				} catch (IOException e) {
+					logger.warn("Error occured when close the reader of user dictionary. :" + userDictionary);
+				}
+			}
+			return null;
+		}
+
+		public static Mode createMode(String mode) {
+			try {
+				if (StringUtil.isEmpty(mode)) {
+					return Mode.SEARCH;
+				}
+				return Mode.valueOf(mode);
+			} catch (IllegalArgumentException e) {
+				return Mode.SEARCH;
+			}
+		}
+
+		public static CharArraySet createStopwords(String stopwords) {
+			if (StringUtil.isEmpty(stopwords)) {
+				return JapaneseAnalyzer.getDefaultStopSet();
+			}
+
+			try {
+				return StopwordAnalyzerBase.loadStopwordSet(true, AnalyzerFactoryJapaneseAnalyzer.class, stopwords, "#");
+			} catch (IOException e) {
+				logger.warn("Unable to load stopword set : " + stopwords + ",  So use default one.");
+			}
+			return JapaneseAnalyzer.getDefaultStopSet();
+		}
+
+		public static Set<String> createStopTags(String stoptags) {
+			if (StringUtil.isEmpty(stoptags)) {
+				return JapaneseAnalyzer.getDefaultStopTags();
+			}
+
+			try {
+				final CharArraySet tagset = StopwordAnalyzerBase.loadStopwordSet(false, AnalyzerFactoryJapaneseAnalyzer.class, stoptags, "#");
+				Set<String> tags = new HashSet<>();
+				for (Object element : tagset) {
+					char chars[] = (char[]) element;
+					tags.add(new String(chars));
+				}
+				return tags;
+			} catch (IOException e) {
+				logger.warn("Unable to load stoptag set : " + stoptags + ", So use default one.");
+			}
+			return JapaneseAnalyzer.getDefaultStopTags();
+		}
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/AnalyzerSetting.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/AnalyzerSetting.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2012 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.iplass.mtp.impl.fulltextsearch;
+
+public class AnalyzerSetting {
+
+	private String userDictionary;
+	private String stopwords;
+	private String stoptags;
+	private String mode;
+
+	public String getUserDictionary() {
+		return userDictionary;
+	}
+
+	public void setUserDictionary(String userDictionary) {
+		this.userDictionary = userDictionary;
+	}
+
+	public String getStopwords() {
+		return stopwords;
+	}
+
+	public void setStopwords(String stopwords) {
+		this.stopwords = stopwords;
+	}
+
+	public String getStoptags() {
+		return stoptags;
+	}
+
+	public void setStoptags(String stoptags) {
+		this.stoptags = stoptags;
+	}
+
+	public String getMode() {
+		return mode;
+	}
+
+	public void setMode(String mode) {
+		this.mode = mode;
+	}
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchLuceneService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchLuceneService.java
@@ -245,12 +245,12 @@ public class FulltextSearchLuceneService extends AbstractFulltextSeachService {
 		try {
 			String className = config.getValue("analyzer");
 			if (StringUtil.isNotEmpty(className)) {
-				analyzer = (Analyzer) Class.forName(config.getValue("analyzer")).getConstructor().newInstance();
+				analyzer = AnalyzerFactory.createAnalyzer(className, config.getValue("analyzerSetting", AnalyzerSetting.class));
 			} else {
 				analyzer = (Analyzer) config.getBean("analyzer");
 			}
 		} catch (Exception e) {
-			logger.warn("Analyzer not found. use JapaneseAnalyzer(mode:search). : " + config.getValue("analyzer"));
+			logger.warn("Analyzer not found. use JapaneseAnalyzer(mode:search). : " + config.getValue("analyzer"), e);
 			analyzer = new JapaneseAnalyzer();
 		}
 		defaultOperator = Operator.valueOf(config.getValue("defaultOperator"));
@@ -582,7 +582,9 @@ public class FulltextSearchLuceneService extends AbstractFulltextSeachService {
 			}
 			luceneQuery = setEntityDefCondition(luceneQuery, defNameList.toArray(new String[defNameList.size()]));
 
-			logger.debug("lucene query : " + luceneQuery.toString());
+			if (logger.isDebugEnabled()) {
+				logger.debug("lucene query : " + luceneQuery.build().toString());
+			}
 
 			TopDocs docs = searcher.search(luceneQuery.build(), getMaxRows(), getDefaultSort(), true, false);
 			ScoreDoc[] hits = docs.scoreDocs;
@@ -731,7 +733,9 @@ public class FulltextSearchLuceneService extends AbstractFulltextSeachService {
 			luceneQuery = setTenantCondition(qp, luceneQuery);
 			luceneQuery = setEntityDefCondition(luceneQuery, searchDefName);
 
-			logger.debug("lucene query : " + luceneQuery.toString());
+			if (logger.isDebugEnabled()) {
+				logger.debug("lucene query : " + luceneQuery.build().toString());
+			}
 
 			TopDocs docs = searcher.search(luceneQuery.build(), allIndexCount);
 			ScoreDoc[] hits = docs.scoreDocs;
@@ -784,7 +788,9 @@ public class FulltextSearchLuceneService extends AbstractFulltextSeachService {
 			luceneQuery = setTenantCondition(qp, luceneQuery);
 			luceneQuery = setEntityDefCondition(luceneQuery, searchDefName);
 
-			logger.debug("lucene query : " + luceneQuery.toString());
+			if (logger.isDebugEnabled()) {
+				logger.debug("lucene query : " + luceneQuery.build().toString());
+			}
 
 			TopDocs docs = searcher.search(luceneQuery.build(), getMaxRows(), getDefaultSort());
 			ScoreDoc[] hits = docs.scoreDocs;


### PR DESCRIPTION
FulltextSearchLuceneService、次の改善

-  FulltextSearchLuceneServiceにユーザ定義辞書を追加できるようにする

```
<service>
	<interface>org.iplass.mtp.impl.fulltextsearch.FulltextSearchService</interface>
	.......

	<!-- lucene利用 -->
	<class>org.iplass.mtp.impl.fulltextsearch.FulltextSearchLuceneService</class>
	.......
	
	<property name="analyzerSetting" class="org.iplass.mtp.impl.fulltextsearch.AnalyzerSetting">
		<property name="userDictionary" value="/lucene/userdict.txt" />
		<property name="stopwords" value="/lucene/stoptags.txt" />
		<property name="stoptags" value="/lucene/stopwords.txt" />
		<property name="mode" value="SEARCH" />
	</property>
	......
	
</service>
```
FulltextSearchLuceneServiceのservcer-configに新規の設定項目analyzerSettingを追加しました。analyzerSetting自体と各サブプロパティの設定値は省略可能です。

1. userDictionary : ユーザ定義辞書
1. stopwords : ストップワード定義ファイル
1. stoptags : ストップタグ定義ファイル
1. mode: モード


