### PR TITLE
ネストテーブルの編集リンクでデータを登録した場合に二重で登録されてしまう

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
@@ -2906,6 +2906,9 @@ function addNestRow(rowId, countId, multiplicy, insertTop, rootDefName, viewName
 		$("[name]", $copyRow).each(function() {
 			replaceDummyAttr(this, "name", idx);
 		});
+		$("[data-name]", $copyRow).each(function() {
+			replaceDummyAttr(this, "data-name", idx);
+		});
 		$copyRow.addClass("stripeRow");
 
 		//形式による置換以外の処理


### PR DESCRIPTION
#83 対応。

NestTableの編集リンクでの編集結果保存後の参照側登録における不具合。