### PR TITLE
WebAPI定義にてCache-Controlを設定可能にする #93

### DIFF
--- a/iplass-admin/build.gradle
+++ b/iplass-admin/build.gradle
@@ -300,6 +300,7 @@ task copyGwtTransSrc(type: Sync) {
 		include 'mtp/webapi/definition/EntityWebApiDefinition.java'
 		include 'mtp/webapi/definition/MethodType.java'
 		include 'mtp/webapi/definition/StateType.java'
+		include 'mtp/webapi/definition/CacheControlType.java'
 		include 'mtp/webapi/definition/WebApiDefinition.java'
 		include 'mtp/webapi/definition/WebApiDefinitionModifyResult.java'
 		include 'mtp/webapi/definition/WebApiTokenCheck.java'

--- a/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
 
 import org.iplass.mtp.command.annotation.CommandConfig;
 import org.iplass.mtp.webapi.WebApiRequestConstants;
+import org.iplass.mtp.webapi.definition.CacheControlType;
 import org.iplass.mtp.webapi.definition.RequestType;
 import org.iplass.mtp.webapi.definition.MethodType;
 import org.iplass.mtp.webapi.definition.StateType;
@@ -102,13 +103,4 @@ public @interface WebApi {
 	boolean synchronizeOnSession() default false;
 
 	String responseType() default "";
-	
-	/**
-	 * WebAPIのキャッシュ設定のenumです。<br>
-	 * CACHE : "Cache-Control:private"をセット<br>
-	 * NO_CACHE : "Cache-Control:no-store,no-cache"をセット
-	 */
-	public enum CacheControlType {
-		CACHE, NO_CACHE, UNSPECIFIED
-	}
 }

--- a/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
@@ -48,6 +48,24 @@ public @interface WebApi {
 	String name();
 	String displayName() default "##default";
 	String description() default "##default";
+	
+	/**
+	 * WebAPIのキャッシュ種別（Cache-Controlヘッダの制御）を設定します。
+	 * デフォルトは、UNSPECIFIED（未指定）です。
+	 * 
+	 * @return WebAPIのキャッシュ種別
+	 */
+	CacheControlType cacheControlType() default CacheControlType.UNSPECIFIED;
+
+	/**
+	 * cacheControlType=CACHEを指定した場合の
+	 * WebAPIキャッシュのmax-age（秒）を指定します。
+	 * デフォルト値は-1でこの場合はmax-ageは未指定となります。<br>
+	 * <b>注意：max-age未指定の場合、FF、Chromeでは実際はキャッシュが利用されません</b>
+	 * 
+	 * @param cacheControlMaxAge
+	 */
+	long cacheControlMaxAge() default -1;
 
 	boolean checkXRequestedWithHeader() default true;
 	boolean privilaged() default false;
@@ -84,4 +102,13 @@ public @interface WebApi {
 	boolean synchronizeOnSession() default false;
 
 	String responseType() default "";
+	
+	/**
+	 * WebAPIのキャッシュ設定のenumです。<br>
+	 * CACHE : "Cache-Control:private"をセット<br>
+	 * NO_CACHE : "Cache-Control:no-store,no-cache"をセット
+	 */
+	public enum CacheControlType {
+		CACHE, NO_CACHE, UNSPECIFIED
+	}
 }

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApi.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApi.java
@@ -54,6 +54,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.webapi.WebApiRuntimeException;
 import org.iplass.mtp.webapi.definition.RequestType;
+import org.iplass.mtp.webapi.definition.CacheControlType;
 import org.iplass.mtp.webapi.definition.MethodType;
 import org.iplass.mtp.webapi.definition.StateType;
 import org.iplass.mtp.webapi.definition.WebApiDefinition;
@@ -77,6 +78,9 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 	private MethodType[] methods;
 	private StateType state = StateType.STATEFUL;
 	private boolean supportBearerToken;
+
+	private CacheControlType cacheControlType;
+	private long cacheControlMaxAge = -1;
 
 	private String restJsonParameterName = null;
 	private Class<?> restJsonParameterType = void.class;
@@ -269,6 +273,22 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 
 	public void setRestXmlParameterName(String restXmlParameterName) {
 		this.restXmlParameterName = restXmlParameterName;
+	}
+
+	public CacheControlType getCacheControlType() {
+		return cacheControlType;
+	}
+
+	public void setCacheControlType(CacheControlType cacheControlType) {
+		this.cacheControlType = cacheControlType;
+	}
+
+	public long getCacheControlMaxAge() {
+		return cacheControlMaxAge;
+	}
+
+	public void setCacheControlMaxAge(long cacheControlMaxAge) {
+		this.cacheControlMaxAge = cacheControlMaxAge;
 	}
 
 	public class WebApiRuntime extends BaseMetaDataRuntime {
@@ -534,6 +554,9 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 		definition.setState(state);
 		definition.setSupportBearerToken(supportBearerToken);
 
+		definition.setCacheControlType(cacheControlType);
+		definition.setCacheControlMaxAge(cacheControlMaxAge);
+
 		definition.setPrivilaged(isPrivilaged);
 		definition.setPublicWebApi(isPublicWebApi);
 		definition.setCheckXRequestedWithHeader(isCheckXRequestedWithHeader);
@@ -592,6 +615,8 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 		state = definition.getState();
 		supportBearerToken = definition.isSupportBearerToken();
 
+		cacheControlType = definition.getCacheControlType();
+		cacheControlMaxAge = definition.getCacheControlMaxAge();
 
 		if (definition.getCommandConfig() != null) {
 			command = MetaCommand.createInstance(definition.getCommandConfig());

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
@@ -30,6 +30,7 @@ import org.iplass.mtp.impl.command.MetaCommand;
 import org.iplass.mtp.impl.command.MetaCommandFactory;
 import org.iplass.mtp.impl.metadata.annotation.AnnotatableMetaDataFactory;
 import org.iplass.mtp.impl.metadata.annotation.AnnotateMetaDataEntry;
+import org.iplass.mtp.webapi.definition.CacheControlType;
 
 
 public class MetaWebApiFactory implements AnnotatableMetaDataFactory<WebApi, Command> {
@@ -110,10 +111,10 @@ public class MetaWebApiFactory implements AnnotatableMetaDataFactory<WebApi, Com
 		if (webapi.cacheControlType() != null) {
 			switch (webapi.cacheControlType()) {
 				case CACHE:
-					meta.setCacheControlType(org.iplass.mtp.webapi.definition.CacheControlType.CACHE);
+					meta.setCacheControlType(CacheControlType.CACHE);
 					break;
 				case NO_CACHE:
-					meta.setCacheControlType(org.iplass.mtp.webapi.definition.CacheControlType.NO_CACHE);
+					meta.setCacheControlType(CacheControlType.NO_CACHE);
 					break;
 				default:
 					break;

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
@@ -107,6 +107,20 @@ public class MetaWebApiFactory implements AnnotatableMetaDataFactory<WebApi, Com
 			}
 		}
 
+		if (webapi.cacheControlType() != null) {
+			switch (webapi.cacheControlType()) {
+				case CACHE:
+					meta.setCacheControlType(org.iplass.mtp.webapi.definition.CacheControlType.CACHE);
+					break;
+				case NO_CACHE:
+					meta.setCacheControlType(org.iplass.mtp.webapi.definition.CacheControlType.NO_CACHE);
+					break;
+				default:
+					break;
+			}
+		}
+		meta.setCacheControlMaxAge(webapi.cacheControlMaxAge());
+
 		meta.setAccepts(webapi.accepts());
 		meta.setMethods(webapi.methods());
 		meta.setResults(webapi.results());

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestCommandInvoker.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestCommandInvoker.java
@@ -63,6 +63,7 @@ import org.iplass.mtp.command.RequestContext;
 import org.iplass.mtp.impl.session.SessionService;
 import org.iplass.mtp.impl.web.RequestPath;
 import org.iplass.mtp.impl.web.WebRequestStack;
+import org.iplass.mtp.impl.web.WebUtil;
 import org.iplass.mtp.impl.webapi.MetaWebApi;
 import org.iplass.mtp.impl.webapi.MetaWebApi.WebApiRuntime;
 import org.iplass.mtp.impl.webapi.WebApiParameter;
@@ -76,6 +77,7 @@ import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.webapi.WebApiRequestConstants;
 import org.iplass.mtp.webapi.WebApiRuntimeException;
 import org.iplass.mtp.webapi.definition.RequestType;
+import org.iplass.mtp.webapi.definition.CacheControlType;
 import org.iplass.mtp.webapi.definition.MethodType;
 import org.iplass.mtp.webapi.definition.StateType;
 import org.slf4j.Logger;
@@ -159,6 +161,19 @@ public class RestCommandInvoker {
 			onlyOneRes = result.getResults().values().iterator().next();
 		}
 		
+		if (runtime.getMetaData().getCacheControlType() != null) {
+			switch (runtime.getMetaData().getCacheControlType()) {
+			case CACHE:
+				WebUtil.setCacheControlHeader(stack, true, runtime.getMetaData().getCacheControlMaxAge());
+				break;
+			case NO_CACHE:
+				WebUtil.setCacheControlHeader(stack, false, -1);
+				break;
+			default:
+				break;
+			}
+		}
+
 		if (onlyOneRes instanceof ResponseBuilder) {
 			return ((ResponseBuilder) onlyOneRes).build();
 		} else if (onlyOneRes instanceof StreamingOutput) {

--- a/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/CacheControlType.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/CacheControlType.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ * 
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.iplass.mtp.webapi.definition;
+
+/**
+ * WebAPIキャッシュ指定（Cache-Controlヘッダ）の種別です。
+ */
+public enum CacheControlType {
+
+	/**
+	 * キャッシュを許可します。
+	 * 具体的にはCache-Controlをprivate指定します。
+	 * CACHEを指定する場合は、合わせてclientCacheMaxAgeも指定してください。
+	 * 
+	 */
+	CACHE,
+	
+	/**
+	 * キャッシュを許可しません。
+	 * 具体的にはCache-Controlをno-store,no-cache指定します
+	 * （加えて、HTTP/1.0の場合は、Pragmaをno-cache指定します）。
+	 * 
+	 */
+	NO_CACHE;
+
+}

--- a/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/CacheControlType.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/CacheControlType.java
@@ -39,6 +39,11 @@ public enum CacheControlType {
 	 * （加えて、HTTP/1.0の場合は、Pragmaをno-cache指定します）。
 	 * 
 	 */
-	NO_CACHE;
+	NO_CACHE,
 
+	/**
+	 * キャッシュ設定は未指定です。
+	 * 具体的にはCache-Controlを指定しません。
+	 */
+	UNSPECIFIED;
 }

--- a/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/WebApiDefinition.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/WebApiDefinition.java
@@ -36,6 +36,15 @@ public class WebApiDefinition implements Definition {
 	private String name;
 	private String displayName;
 	private String description;
+	
+	/**
+	 * WebAPIキャッシュ指定。
+	 * 未指定の場合はキャッシュをしない。
+	 */
+	private CacheControlType cacheControlType;
+
+	/** WebAPIキャッシュのmax-age（秒）*/
+	private long cacheControlMaxAge = -1;
 
 	/**
 	 * このWebApiが呼び出されたときに実行するCommand。
@@ -254,6 +263,46 @@ public class WebApiDefinition implements Definition {
 	 */
 	public void setDescription(String description) {
 		this.description = description;
+	}
+
+	/**
+	 * @see #setCacheControlType(cacheControlType)
+	 * @return cacheControlType
+	 */
+	public CacheControlType getCacheControlType() {
+		return cacheControlType;
+	}
+
+	/**
+	 * WebAPIキャッシュ指定（Cache-Controlヘッダの制御）。
+	 * 未指定の場合はキャッシュをしない。
+	 * ブラウザ種別によらず、キャッシュを有効化するためには、合わせてCacheControlMaxAgeの設定も必要。
+	 * 
+	 * @see #setCacheControlMaxAge(long)
+	 * @param cacheControlType
+	 */
+	public void setCacheControlType(CacheControlType cacheControlType) {
+		this.cacheControlType = cacheControlType;
+	}
+
+	/**
+	 * @see #setCacheControlMaxAge(long)
+	 * @return
+	 */
+	public long getCacheControlMaxAge() {
+		return cacheControlMaxAge;
+	}
+
+	/**
+	 * cacheControlMaxAge=CacheControlType.CACHEを指定した場合の
+	 * WebAPIキャッシュのmax-age（秒）を指定。
+	 * デフォルト値は-1でこの場合はmax-ageは未指定となる。<br>
+	 * <b>注意：max-age未指定の場合、FF、Chromeでは実際はキャッシュが利用されない</b>
+	 * 
+	 * @param cacheControlMaxAge
+	 */
+	public void setCacheControlMaxAge(long cacheControlMaxAge) {
+		this.cacheControlMaxAge = cacheControlMaxAge;
 	}
 
 	/**


### PR DESCRIPTION
WebAPI定義にてCache-Controlを設定可能にする。
Action定義と同様な形で。
https://github.com/ISID/iPLAss/issues/93 対応。