### PR TITLE
プロパティを削除した後に画面定義を保存できなくなる

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/HasEntityProperty.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/HasEntityProperty.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2019 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package org.iplass.mtp.impl.view.generic;
+
+import org.iplass.mtp.impl.entity.EntityContext;
+import org.iplass.mtp.impl.entity.EntityHandler;
+import org.iplass.mtp.impl.entity.property.PropertyHandler;
+import org.iplass.mtp.impl.entity.property.ReferencePropertyHandler;
+
+/**
+ * EntityのProperty情報を保持しているElement定義
+ */
+public interface HasEntityProperty {
+
+	/**
+	 * プロパティIDからプロパティ名を取得します。
+	 *
+	 * @param propId プロパティID
+	 * @param context Entityコンテキスト
+	 * @param entity 対象のEntity定義
+	 * @return プロパティ名
+	 */
+	default String convertName(String propId, EntityContext context, EntityHandler entity) {
+
+		//idから復元できない場合→プロパティが消された等が考えられるので、
+		//Exceptionを投げずにnullで返しておく
+		if (propId != null && propId.contains(".")) {
+			int indexOfDot = propId.indexOf(".");
+			String objPropId = propId.substring(0, indexOfDot);
+			String subPropPath = propId.substring(indexOfDot + 1, propId.length());
+
+			PropertyHandler property = entity.getPropertyById(objPropId, context);
+			if (!(property instanceof ReferencePropertyHandler)) {
+				return null;
+			}
+			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
+			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
+			if (refEntity == null) {
+				return null;
+			}
+			String refProperty = convertName(subPropPath, context, refEntity);
+			if (refProperty == null) {
+				return null;
+			}
+			return property.getName() + "." + refProperty;
+		} else {
+			PropertyHandler property = entity.getPropertyById(propId, context);
+			if (property == null) {
+				return null;
+			}
+			return property.getName();
+		}
+	}
+
+	/**
+	 * プロパティ名からプロパティIDを取得します。
+	 *
+	 * @param propName プロパティ名
+	 * @param context Entityコンテキスト
+	 * @param entity 対象のEntity定義
+	 * @return プロパティID
+	 */
+	default String convertId(String propName, EntityContext context, EntityHandler entity) {
+
+		if (propName == null || propName.isEmpty()) {
+			return null;
+		}
+		if (propName.contains(".")) {
+			int indexOfDot = propName.indexOf('.');
+			String objPropName = propName.substring(0, indexOfDot);
+			String subPropPath = propName.substring(indexOfDot + 1, propName.length());
+
+			PropertyHandler property = entity.getProperty(objPropName, context);
+			if (!(property instanceof ReferencePropertyHandler)) {
+				throw new IllegalArgumentException("path is invalid:" + objPropName + " is not ObjectReferenceProperty of " + entity.getMetaData().getName());
+			}
+			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
+			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
+			if (refEntity == null) {
+				throw new IllegalArgumentException(objPropName + "'s Entity is not defined.");
+			}
+			String refProperty = convertId(subPropPath, context, refEntity);
+			if (refProperty == null) {
+				throw new IllegalArgumentException(subPropPath + "'s Property is not defined.");
+			}
+			return property.getId() + "." + refProperty;
+
+		} else {
+			PropertyHandler property = entity.getProperty(propName, context);
+			if (property == null) {
+				throw new IllegalArgumentException(propName + "'s Property is not defined.");
+			}
+			return property.getId();
+		}
+	}
+}

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/common/MetaAutocompletionProperty.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/common/MetaAutocompletionProperty.java
@@ -22,13 +22,12 @@ package org.iplass.mtp.impl.view.generic.common;
 
 import org.iplass.mtp.impl.entity.EntityContext;
 import org.iplass.mtp.impl.entity.EntityHandler;
-import org.iplass.mtp.impl.entity.property.PropertyHandler;
-import org.iplass.mtp.impl.entity.property.ReferencePropertyHandler;
 import org.iplass.mtp.impl.metadata.MetaData;
 import org.iplass.mtp.impl.util.ObjectUtil;
+import org.iplass.mtp.impl.view.generic.HasEntityProperty;
 import org.iplass.mtp.view.generic.common.AutocompletionProperty;
 
-public class MetaAutocompletionProperty implements MetaData {
+public class MetaAutocompletionProperty implements MetaData, HasEntityProperty {
 
 	private static final long serialVersionUID = 8665280705434279354L;
 
@@ -102,39 +101,6 @@ public class MetaAutocompletionProperty implements MetaData {
 		referencePropertyIndex = property.getReferencePropertyIndex();
 	}
 
-	private String convertId(String propName, EntityContext context, EntityHandler entity) {
-		if (propName == null || propName.isEmpty()) {
-			return null;
-		}
-		if (propName.contains(".")) {
-			int indexOfDot = propName.indexOf('.');
-			String objPropName = propName.substring(0, indexOfDot);
-			String subPropPath = propName.substring(indexOfDot + 1, propName.length());
-
-			PropertyHandler property = entity.getProperty(objPropName, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				throw new IllegalArgumentException("path is invalid:" + objPropName + " is not ObjectReferenceProperty of " + entity.getMetaData().getName());
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				throw new IllegalArgumentException(objPropName + "'s Entity is not defined.");
-			}
-			String refProperty = convertId(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				throw new IllegalArgumentException(subPropPath + "'s Property is not defined.");
-			}
-			return property.getId() + "." + refProperty;
-
-		} else {
-			PropertyHandler property = entity.getProperty(propName, context);
-			if (property == null) {
-				throw new IllegalArgumentException(propName + "'s Property is not defined.");
-			}
-			return property.getId();
-		}
-	}
-
 	public AutocompletionProperty currentConfig(EntityHandler refEntity, EntityHandler rootEntity) {
 		String _name = null;
 		if (rootEntity == null || nestProperty) {
@@ -151,34 +117,4 @@ public class MetaAutocompletionProperty implements MetaData {
 		return property;
 	}
 
-	private String convertName(String id, EntityContext context, EntityHandler entity) {
-		//idから復元できない場合→プロパティが消された等が考えられるので、
-		//Exceptionを投げずにnullで返しておく
-		if (id != null && id.contains(".")) {
-			int indexOfDot = id.indexOf(".");
-			String objPropId = id.substring(0, indexOfDot);
-			String subPropPath = id.substring(indexOfDot + 1, id.length());
-
-			PropertyHandler property = entity.getPropertyById(objPropId, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				return null;
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				return null;
-			}
-			String refProperty = convertName(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				return null;
-			}
-			return property.getName() + "." + refProperty;
-		} else {
-			PropertyHandler property = entity.getPropertyById(id, context);
-			if (property == null) {
-				return null;
-			}
-			return property.getName();
-		}
-	}
 }

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/MetaElement.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/MetaElement.java
@@ -108,15 +108,15 @@ public abstract class MetaElement implements MetaData {
 	}
 
 	/**
-	 * 要素の内容を自身に適用。
-	 * @param element 要素
+	 * エレメントの設定をメタデータに反映します。
+	 * @param element エレメント定義
 	 * @param definitionId Entity定義のID
 	 */
 	public abstract void applyConfig(Element element, String definitionId);
 
 	/**
-	 * 自身の属性に要素の属性の値をセット
-	 * @param element 要素
+	 * エレメント共通の設定をメタデータに反映します。
+	 * @param element エレメント定義
 	 * @param definitionId Entity定義のID
 	 */
 	protected void fillFrom(Element element, String definitionId) {
@@ -125,15 +125,15 @@ public abstract class MetaElement implements MetaData {
 	}
 
 	/**
-	 * 自身の内容を要素に適用。
+	 * メタデータからエレメントを生成します。
 	 * @param definitionId Entity定義のID
-	 * @return 要素
+	 * @return エレメント
 	 */
 	public abstract Element currentConfig(String definitionId);
 
 	/**
-	 * 要素の属性に自身の属性の値をセット
-	 * @param element 要素
+	 * メタデータ共通の設定をエレメントに反映します。
+	 * @param element エレメント定義
 	 * @param definitionId Entity定義のID
 	 */
 	protected void fillTo(Element element, String definitionId) {

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/MetaPropertyColumn.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/MetaPropertyColumn.java
@@ -25,15 +25,10 @@ import javax.xml.bind.annotation.XmlAccessorType;
 
 import org.iplass.mtp.impl.entity.EntityContext;
 import org.iplass.mtp.impl.entity.EntityHandler;
-import org.iplass.mtp.impl.entity.property.PropertyHandler;
-import org.iplass.mtp.impl.entity.property.ReferencePropertyHandler;
 import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor;
 import org.iplass.mtp.view.generic.NullOrderType;
 import org.iplass.mtp.view.generic.RequiredDisplayType;
 import org.iplass.mtp.view.generic.TextAlign;
-import org.iplass.mtp.view.generic.editor.DateRangePropertyEditor;
-import org.iplass.mtp.view.generic.editor.JoinPropertyEditor;
-import org.iplass.mtp.view.generic.editor.ReferencePropertyEditor;
 import org.iplass.mtp.view.generic.element.Element;
 import org.iplass.mtp.view.generic.element.property.PropertyColumn;
 
@@ -179,6 +174,11 @@ public class MetaPropertyColumn extends MetaPropertyLayout {
 		//ReferencePropertyEditorは参照先Entityがない場合null。
 		//その場合はElementもnullで返す。
 		if (p.getEditor() == null) {
+			return null;
+		}
+
+		//プロパティ名が取得できない場合はnullを返す
+		if (p.getPropertyName() == null) {
 			return null;
 		}
 

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/MetaPropertyItem.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/MetaPropertyItem.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2011 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -344,6 +344,11 @@ public class MetaPropertyItem extends MetaPropertyLayout {
 		//ReferencePropertyEditorは参照先Entityがない場合null。
 		//その場合はElementもnullで返す。
 		if (p.getEditor() == null) {
+			return null;
+		}
+
+		//プロパティ名が取得できない場合はnullを返す
+		if (p.getPropertyName() == null) {
 			return null;
 		}
 

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/MetaPropertyLayout.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/MetaPropertyLayout.java
@@ -35,6 +35,7 @@ import org.iplass.mtp.impl.i18n.I18nUtil;
 import org.iplass.mtp.impl.i18n.MetaLocalizedString;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.impl.view.generic.EntityViewHandler;
+import org.iplass.mtp.impl.view.generic.HasEntityProperty;
 import org.iplass.mtp.impl.view.generic.common.MetaAutocompletionSetting;
 import org.iplass.mtp.impl.view.generic.common.MetaAutocompletionSetting.AutocompletionSettingHandler;
 import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor;
@@ -55,7 +56,7 @@ import org.iplass.mtp.view.generic.element.property.PropertyItem;
  */
 @XmlSeeAlso({ MetaPropertyItem.class, MetaPropertyColumn.class })
 @XmlAccessorType(XmlAccessType.FIELD)
-public abstract class MetaPropertyLayout extends MetaElement {
+public abstract class MetaPropertyLayout extends MetaElement implements HasEntityProperty {
 
 	/** シリアルバージョンUID */
 	private static final long serialVersionUID = 1940139489715422445L;
@@ -249,39 +250,6 @@ public abstract class MetaPropertyLayout extends MetaElement {
 		}
 	}
 
-	private String convertId(String propName, EntityContext context, EntityHandler entity) {
-		if (propName == null || propName.isEmpty()) {
-			return null;
-		}
-		if (propName.contains(".")) {
-			int indexOfDot = propName.indexOf('.');
-			String objPropName = propName.substring(0, indexOfDot);
-			String subPropPath = propName.substring(indexOfDot + 1, propName.length());
-
-			PropertyHandler property = entity.getProperty(objPropName, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				throw new IllegalArgumentException("path is invalid:" + objPropName + " is not ObjectReferenceProperty of " + entity.getMetaData().getName());
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				throw new IllegalArgumentException(objPropName + "'s Entity is not defined.");
-			}
-			String refProperty = convertId(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				throw new IllegalArgumentException(subPropPath + "'s Property is not defined.");
-			}
-			return property.getId() + "." + refProperty;
-
-		} else {
-			PropertyHandler property = entity.getProperty(propName, context);
-			if (property == null) {
-				throw new IllegalArgumentException(propName + "'s Property is not defined.");
-			}
-			return property.getId();
-		}
-	}
-
 	private PropertyHandler getHandler(String propName, EntityContext context, EntityHandler entity) {
 		if (propName == null || propName.isEmpty()) {
 			return null;
@@ -349,37 +317,6 @@ public abstract class MetaPropertyLayout extends MetaElement {
 		}
 
 		p.setLocalizedDisplayLabelList(I18nUtil.toDef(localizedDisplayLabelList));
-	}
-
-	private String convertName(String id, EntityContext context, EntityHandler entity) {
-		//idから復元できない場合→プロパティが消された等が考えられるので、
-		//Exceptionを投げずにnullで返しておく
-		if (id != null && id.contains(".")) {
-			int indexOfDot = id.indexOf(".");
-			String objPropId = id.substring(0, indexOfDot);
-			String subPropPath = id.substring(indexOfDot + 1, id.length());
-
-			PropertyHandler property = entity.getPropertyById(objPropId, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				return null;
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				return null;
-			}
-			String refProperty = convertName(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				return null;
-			}
-			return property.getName() + "." + refProperty;
-		} else {
-			PropertyHandler property = entity.getPropertyById(id, context);
-			if (property == null) {
-				return null;
-			}
-			return property.getName();
-		}
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/validation/MetaPropertyValidationCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/property/validation/MetaPropertyValidationCondition.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2016 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -22,17 +22,16 @@ package org.iplass.mtp.impl.view.generic.element.property.validation;
 
 import org.iplass.mtp.impl.entity.EntityContext;
 import org.iplass.mtp.impl.entity.EntityHandler;
-import org.iplass.mtp.impl.entity.property.PropertyHandler;
-import org.iplass.mtp.impl.entity.property.ReferencePropertyHandler;
 import org.iplass.mtp.impl.metadata.MetaData;
 import org.iplass.mtp.impl.util.ObjectUtil;
+import org.iplass.mtp.impl.view.generic.HasEntityProperty;
 import org.iplass.mtp.view.generic.element.property.validation.PropertyValidationCondition;
 
 /**
  * 入力チェックの条件となるプロパティ
  * @author lis3wg
  */
-public class MetaPropertyValidationCondition implements MetaData {
+public class MetaPropertyValidationCondition implements MetaData, HasEntityProperty {
 
 	private static final long serialVersionUID = 8091733440414624844L;
 
@@ -66,39 +65,6 @@ public class MetaPropertyValidationCondition implements MetaData {
 		this.propertyId = convertId(condition.getPropertyName(), context, entity);
 	}
 
-	private String convertId(String propName, EntityContext context, EntityHandler entity) {
-		if (propName == null || propName.isEmpty()) {
-			throw new IllegalArgumentException("sortKey is invalid:sortKey is not allow set null or empty.");
-		}
-		if (propName.contains(".")) {
-			int indexOfDot = propName.indexOf('.');
-			String objPropName = propName.substring(0, indexOfDot);
-			String subPropPath = propName.substring(indexOfDot + 1, propName.length());
-
-			PropertyHandler property = entity.getProperty(objPropName, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				throw new IllegalArgumentException("path is invalid:" + objPropName + " is not ObjectReferenceProperty of " + entity.getMetaData().getName());
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				throw new IllegalArgumentException(objPropName + "'s Entity is not defined.");
-			}
-			String refProperty = convertId(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				throw new IllegalArgumentException(subPropPath + "'s Property is not defined.");
-			}
-			return property.getId() + "." + refProperty;
-
-		} else {
-			PropertyHandler property = entity.getProperty(propName, context);
-			if (property == null) {
-				throw new IllegalArgumentException(propName + "'s Property is not defined.");
-			}
-			return property.getId();
-		}
-	}
-
 	/**
 	 * 設定内容を条件に反映。
 	 * @return 条件
@@ -114,37 +80,6 @@ public class MetaPropertyValidationCondition implements MetaData {
 			condition.setPropertyName(propertyName);
 		}
 		return condition;
-	}
-
-	private String convertName(String id, EntityContext context, EntityHandler entity) {
-		//idから復元できない場合→プロパティが消された等が考えられるので、
-		//Exceptionを投げずにnullで返しておく
-		if (id != null && id.contains(".")) {
-			int indexOfDot = id.indexOf(".");
-			String objPropId = id.substring(0, indexOfDot);
-			String subPropPath = id.substring(indexOfDot + 1, id.length());
-
-			PropertyHandler property = entity.getPropertyById(objPropId, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				return null;
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				return null;
-			}
-			String refProperty = convertName(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				return null;
-			}
-			return property.getName() + "." + refProperty;
-		} else {
-			PropertyHandler property = entity.getPropertyById(id, context);
-			if (property == null) {
-				return null;
-			}
-			return property.getName();
-		}
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaDefaultSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaDefaultSection.java
@@ -422,7 +422,7 @@ public class MetaDefaultSection extends MetaSection {
 					if (p != null) section.addElement(p);
 				} else {
 					Element e = fillToElement(elem, definitionId);
-					section.addElement(e);
+					if (e != null) section.addElement(e);
 				}
 			}
 		}
@@ -452,7 +452,6 @@ public class MetaDefaultSection extends MetaSection {
 	private PropertyBase fillToProperty(MetaElement element, String definitionId) {
 		MetaPropertyLayout mp = (MetaPropertyLayout) element;
 		PropertyItem property = (PropertyItem) mp.currentConfig(definitionId);
-		if (property == null || property.getPropertyName() == null) property = null;
 		return property;
 	}
 

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaMassReferenceSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaMassReferenceSection.java
@@ -701,13 +701,14 @@ public class MetaMassReferenceSection extends MetaSection {
 		for (MetaNestProperty mnp : getNestProperties()) {
 			if (refEntity != null) {
 				NestProperty np = mnp.currentConfig(refEntity, entity);
-				if (np != null && np.getPropertyName() != null) section.addProperty(np);
+				if (np != null) section.addProperty(np);
 			}
 		}
 
 		if (!getSortSetting().isEmpty()) {
 			for (MetaSortSetting meta : getSortSetting()) {
-				section.addSortSetting(meta.currentConfig(ctx, refEntity));
+				SortSetting ss = meta.currentConfig(ctx, refEntity);
+				if (ss != null) section.addSortSetting(ss);
 			}
 		}
 

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaReferenceSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaReferenceSection.java
@@ -453,7 +453,7 @@ public class MetaReferenceSection extends MetaSection {
 		}
 		for (MetaNestProperty meta : getProperties()) {
 			NestProperty nest = meta.currentConfig(refEntity, entity);
-			if (nest != null && nest.getPropertyName() != null) section.addProperty(nest);
+			if (nest != null) section.addProperty(nest);
 		}
 		section.setContentScriptKey(contentScriptKey);
 

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSearchConditionSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSearchConditionSection.java
@@ -536,7 +536,10 @@ public class MetaSearchConditionSection extends MetaSection {
 		if (this.getElements().size() > 0) {
 			for (MetaElement elem : this.getElements()) {
 				Element e = elem.currentConfig(definitionId);
-				section.addElement(e);
+				//プロパティが無効な場合など、生成できない場合は追加しない
+				if (e != null) {
+					section.addElement(e);
+				}
 			}
 		}
 		section.setNonOutputOid(this.nonOutputOid);
@@ -552,7 +555,11 @@ public class MetaSearchConditionSection extends MetaSection {
 
 		if (!getSortSetting().isEmpty()) {
 			for (MetaSortSetting meta : getSortSetting()) {
-				section.addSortSetting(meta.currentConfig(ctx, handler));
+				SortSetting s = meta.currentConfig(ctx, handler);
+				//プロパティが無効な場合など、生成できない場合は追加しない
+				if (s != null) {
+					section.addSortSetting(s);
+				}
 			}
 		}
 

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSearchResultSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSearchResultSection.java
@@ -459,7 +459,10 @@ public class MetaSearchResultSection extends MetaSection {
 		if (this.getElements().size() > 0) {
 			for (MetaElement elem : this.getElements()) {
 				Element e = elem.currentConfig(definitionId);
-				section.addElement(e);
+				//プロパティが無効な場合など、生成できない場合は追加しない
+				if (e != null) {
+					section.addElement(e);
+				}
 			}
 		}
 		return section;

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSortSetting.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSortSetting.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2013 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -27,8 +27,8 @@ import org.iplass.mtp.impl.entity.property.ReferencePropertyHandler;
 import org.iplass.mtp.impl.metadata.MetaData;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.view.generic.NullOrderType;
-import org.iplass.mtp.view.generic.element.section.SortSetting;
 import org.iplass.mtp.view.generic.element.section.SearchConditionSection.ConditionSortType;
+import org.iplass.mtp.view.generic.element.section.SortSetting;
 
 public class MetaSortSetting implements MetaData {
 
@@ -136,8 +136,15 @@ public class MetaSortSetting implements MetaData {
 	}
 
 	public SortSetting currentConfig(EntityContext context, EntityHandler entity) {
+
+		//プロパティ名が取得できない場合はnullを返す
+		String name = convertName(sortKey, context, entity);
+		if (name == null) {
+			return null;
+		}
+
 		SortSetting setting = new SortSetting();
-		setting.setSortKey(convertName(sortKey, context, entity));
+		setting.setSortKey(name);
 		setting.setSortType(sortType);
 		setting.setNullOrderType(nullOrderType);
 		return setting;

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSortSetting.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaSortSetting.java
@@ -22,15 +22,14 @@ package org.iplass.mtp.impl.view.generic.element.section;
 
 import org.iplass.mtp.impl.entity.EntityContext;
 import org.iplass.mtp.impl.entity.EntityHandler;
-import org.iplass.mtp.impl.entity.property.PropertyHandler;
-import org.iplass.mtp.impl.entity.property.ReferencePropertyHandler;
 import org.iplass.mtp.impl.metadata.MetaData;
 import org.iplass.mtp.impl.util.ObjectUtil;
+import org.iplass.mtp.impl.view.generic.HasEntityProperty;
 import org.iplass.mtp.view.generic.NullOrderType;
 import org.iplass.mtp.view.generic.element.section.SearchConditionSection.ConditionSortType;
 import org.iplass.mtp.view.generic.element.section.SortSetting;
 
-public class MetaSortSetting implements MetaData {
+public class MetaSortSetting implements MetaData, HasEntityProperty {
 
 	private static final long serialVersionUID = 5223224828928956674L;
 
@@ -102,39 +101,6 @@ public class MetaSortSetting implements MetaData {
 		nullOrderType = setting.getNullOrderType();
 	}
 
-	private String convertId(String propName, EntityContext context, EntityHandler entity) {
-		if (propName == null || propName.isEmpty()) {
-			throw new IllegalArgumentException("sortKey is invalid:sortKey is not allow set null or empty.");
-		}
-		if (propName.contains(".")) {
-			int indexOfDot = propName.indexOf('.');
-			String objPropName = propName.substring(0, indexOfDot);
-			String subPropPath = propName.substring(indexOfDot + 1, propName.length());
-
-			PropertyHandler property = entity.getProperty(objPropName, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				throw new IllegalArgumentException("path is invalid:" + objPropName + " is not ObjectReferenceProperty of " + entity.getMetaData().getName());
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				throw new IllegalArgumentException(objPropName + "'s Entity is not defined.");
-			}
-			String refProperty = convertId(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				throw new IllegalArgumentException(subPropPath + "'s Property is not defined.");
-			}
-			return property.getId() + "." + refProperty;
-
-		} else {
-			PropertyHandler property = entity.getProperty(propName, context);
-			if (property == null) {
-				throw new IllegalArgumentException(propName + "'s Property is not defined.");
-			}
-			return property.getId();
-		}
-	}
-
 	public SortSetting currentConfig(EntityContext context, EntityHandler entity) {
 
 		//プロパティ名が取得できない場合はnullを返す
@@ -150,34 +116,4 @@ public class MetaSortSetting implements MetaData {
 		return setting;
 	}
 
-	private String convertName(String id, EntityContext context, EntityHandler entity) {
-		//idから復元できない場合→プロパティが消された等が考えられるので、
-		//Exceptionを投げずにnullで返しておく
-		if (id != null && id.contains(".")) {
-			int indexOfDot = id.indexOf(".");
-			String objPropId = id.substring(0, indexOfDot);
-			String subPropPath = id.substring(indexOfDot + 1, id.length());
-
-			PropertyHandler property = entity.getPropertyById(objPropId, context);
-			if (!(property instanceof ReferencePropertyHandler)) {
-				return null;
-			}
-			ReferencePropertyHandler refProp = (ReferencePropertyHandler) property;
-			EntityHandler refEntity = refProp.getReferenceEntityHandler(context);
-			if (refEntity == null) {
-				return null;
-			}
-			String refProperty = convertName(subPropPath, context, refEntity);
-			if (refProperty == null) {
-				return null;
-			}
-			return property.getName() + "." + refProperty;
-		} else {
-			PropertyHandler property = entity.getPropertyById(id, context);
-			if (property == null) {
-				return null;
-			}
-			return property.getName();
-		}
-	}
 }


### PR DESCRIPTION
#110 対応。

EntityViewの編集画面を表示する際に、MetaDataからDefinitionに変換を行うが、
このタイミングで無効なプロパティを参照しているエレメントは除外する。
