### PR TITLE
gem、Rererenceの多重度が数値指定されている場合、検索ダイアログで全選択チェックした際のメッセージが正しく表示されない

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/SearchResultSection.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/SearchResultSection.jsp
@@ -1162,8 +1162,9 @@ function closeBulkUpdateModalWindow() {
 <label><input type="radio" name="selectAllType" value="current">${m:rs("mtp-gem-messages", "generic.element.section.SearchResultSection.selectCurrentPage")}</label>
 </li>
 <% 		if (!"-1".equals(multiplicity)) { %>
+<c:set var="multiplicity" value="<%=multiplicity%>" />
 <li class="selectalltype-message">
-<%= TemplateUtil.getResourceString("mtp-gem-messages", "generic.element.section.SearchResultSection.selectAllTypeMessage", multiplicity) %>
+${m:rsp("mtp-gem-messages", "generic.element.section.SearchResultSection.selectAllTypeMessage", multiplicity)}
 </li>
 <% 		} %>
 </ul>


### PR DESCRIPTION
#839 対応