### PR TITLE
AdminCnosoleのserviceクラスのリファクタリング

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/rpc/tenant/TenantServiceImpl.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/rpc/tenant/TenantServiceImpl.java
@@ -100,7 +100,6 @@ public class TenantServiceImpl extends XsrfProtectedServiceServlet implements Te
 	private AdminConsoleService acs = ServiceRegistry.getRegistry().getService(AdminConsoleService.class);
 	private TenantContextService tcs = ServiceRegistry.getRegistry().getService(TenantContextService.class);
 	private I18nService i18n = ServiceRegistry.getRegistry().getService(I18nService.class);
-	private GemConfigService gcs = ServiceRegistry.getRegistry().getService(GemConfigService.class);
 
 	private MetaDataAuditLogger auditLogger = MetaDataAuditLogger.getLogger();
 
@@ -430,6 +429,7 @@ public class TenantServiceImpl extends XsrfProtectedServiceServlet implements Te
 				info.setTenantEntry(entry);
 
 				if (doGetOption) {
+					GemConfigService gcs = ServiceRegistry.getRegistry().getService(GemConfigService.class);
 					info.setSkins(gcs.getSkins());
 					info.setThemes(gcs.getThemes());
 

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/EntityDefinitionOperationController.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/EntityDefinitionOperationController.java
@@ -39,6 +39,13 @@ public interface EntityDefinitionOperationController {
 	public AdminDefinitionModifyResult createMenuItem(EntityDefinition definition);
 
 	/**
+	 * Entity定義に紐づくメニューを更新
+	 * @param definition Entity定義
+	 * @return 処理結果
+	 */
+	public AdminDefinitionModifyResult updateMenuItem(EntityDefinition definition);
+
+	/**
 	 * 画面系の定義をコピー
 	 * @param sourceName 変更元のEntity定義名
 	 * @param newName 変更後のEntity定義名

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/MetaDataServiceImpl.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/MetaDataServiceImpl.java
@@ -152,11 +152,9 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 	private static final Logger logger = LoggerFactory.getLogger(MetaDataServiceImpl.class);
 
 	private EntityDefinitionManager edm = ManagerLocator.getInstance().getManager(EntityDefinitionManager.class);
-	private EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 	private TemplateDefinitionManager tdm = ManagerLocator.getInstance().getManager(TemplateDefinitionManager.class);
 	private ActionMappingDefinitionManager amm = ManagerLocator.getInstance().getManager(ActionMappingDefinitionManager.class);
 	private StaticResourceDefinitionManager srdm = ManagerLocator.getInstance().getManager(StaticResourceDefinitionManager.class);
-	private MenuItemManager mm = ManagerLocator.getInstance().getManager(MenuItemManager.class);
 	private EntityWebApiDefinitionManager ewdm = ManagerLocator.getInstance().getManager(EntityWebApiDefinitionManager.class);
 	private DefinitionManager dm = ManagerLocator.getInstance().getManager(DefinitionManager.class);
 	private WebhookEndpointDefinitionManager wepdm = ManagerLocator.getInstance().getManager(WebhookEndpointDefinitionManager.class);
@@ -728,25 +726,9 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 					}
 
 					// メニューItemの更新
-					MenuItem menuItem = mm.get(convertPath(definition.getName()));
-					if(menuItem != null) {
-						// 更新対象化チェックする
-						String itemDispName = menuItem.getDisplayName();
-						String entityDispName = definition.getDisplayName();
-						if(itemDispName != null && !itemDispName.equals(entityDispName)) {
-							// データは異なる。
-							EntityDefinition oldEd = edm.get(definition.getName());
-							if(itemDispName.equals(oldEd.getDisplayName())) {
-								// メニューと同一(デフォルト)なので修正する
-								menuItem.setDisplayName(definition.getDisplayName());
-
-								auditLogger.logMetadata(MetaDataAction.UPDATE, MenuItem.class.getName(), "name:" + menuItem.getName());
-								DefinitionModifyResult ret = mm.update(menuItem);
-								if (!ret.isSuccess()) {
-									return new AdminDefinitionModifyResult(ret.isSuccess(), ret.getMessage());
-								}
-							}
-						}
+					AdminDefinitionModifyResult ret = ScreenModuleBasedClassFactoryHolder.getFactory().getEntityOperationController().updateMenuItem(definition);
+					if (ret != null) {
+						return ret;
 					}
 
 					//非同期で実行するため、結果を確認しないで正常を返す
@@ -1041,6 +1023,7 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 		return AuthUtil.authCheckAndInvoke(getServletContext(), this.getThreadLocalRequest(), this.getThreadLocalResponse(), tenantId, new AuthUtil.Callable<Map<String, List<String>>>() {
 			@Override
 			public Map<String, List<String>> call() {
+				EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 				Map<String, List<String>> viewsMap = new HashMap<String, List<String>>();
 
 				for (String defName : edm.definitionList()) {
@@ -1083,6 +1066,7 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 			@Override
 			public SearchFormView call() {
 				auditLogger.logMetadata(MetaDataAction.CREATE, SearchFormView.class.getName(), "name:" + name);
+				EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 				return evm.createDefaultSearchFormView(name);
 			}
 		});
@@ -1094,6 +1078,7 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 			@Override
 			public DetailFormView call() {
 				auditLogger.logMetadata(MetaDataAction.CREATE, DetailFormView.class.getName(), "name:" + name);
+				EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 				return evm.createDefaultDetailFormView(name);
 			}
 		});
@@ -1105,6 +1090,7 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 			@Override
 			public BulkFormView call() {
 				auditLogger.logMetadata(MetaDataAction.CREATE, BulkFormView.class.getName(), "name:" + name);
+				EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 				return evm.createDefaultBulkFormView(name);
 			}
 		});
@@ -1135,6 +1121,7 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 			@Override
 			public MenuItemHolder call() {
 
+				MenuItemManager mm = ManagerLocator.getInstance().getManager(MenuItemManager.class);
 				List<String> names = mm.definitionList();
 
 				if (names == null) {
@@ -1169,6 +1156,7 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 				}
 
 				auditLogger.logMetadata(MetaDataAction.CREATE, MenuItem.class.getName(), "name:" + definition.getName());
+				MenuItemManager mm = ManagerLocator.getInstance().getManager(MenuItemManager.class);
 				DefinitionModifyResult ret = mm.create(definition);
 				return new AdminDefinitionModifyResult(ret.isSuccess(), ret.getMessage());
 			}
@@ -1188,6 +1176,7 @@ public class MetaDataServiceImpl extends XsrfProtectedServiceServlet implements 
 				}
 
 				auditLogger.logMetadata(MetaDataAction.UPDATE, MenuItem.class.getName(), "name:" + definition.getName());
+				MenuItemManager mm = ManagerLocator.getInstance().getManager(MenuItemManager.class);
 				DefinitionModifyResult ret = mm.update(definition);
 				return new AdminDefinitionModifyResult(ret.isSuccess(), ret.getMessage());
 			}

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/refrect/RefrectionServiceImpl.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/metadata/rpc/refrect/RefrectionServiceImpl.java
@@ -61,8 +61,6 @@ public class RefrectionServiceImpl extends XsrfProtectedServiceServlet implement
 	private static final long serialVersionUID = 5813243665867941856L;
 	private static final Logger logger = LoggerFactory.getLogger(RefrectionServiceImpl.class);
 
-	private EntityViewService evs = ServiceRegistry.getRegistry().getService(EntityViewService.class);
-
 	/**
 	 * インターフェースクラスを解析して、フィールド情報を各フィールドの値を取得する。
 	 *
@@ -314,6 +312,7 @@ public class RefrectionServiceImpl extends XsrfProtectedServiceServlet implement
 			getFieldInfo(list, cls.getSuperclass(), ignoreFields);
 		}
 
+		EntityViewService evs = ServiceRegistry.getRegistry().getService(EntityViewService.class);
 		for (Field field : cls.getDeclaredFields()) {
 			MetaFieldInfo annotation = field.getAnnotation(MetaFieldInfo.class);
 			if (annotation != null && !ignoreFields.contains(field.getName())) {

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/entityexplorer/EntityConfigDownloadServiceImpl.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/entityexplorer/EntityConfigDownloadServiceImpl.java
@@ -66,7 +66,6 @@ public class EntityConfigDownloadServiceImpl extends AdminDownloadService {
 	private static final long serialVersionUID = -3459617043325559477L;
 
 	private EntityDefinitionManager edm;
-	private EntityViewManager evm;
 	private DefinitionService ds;
 	private AdminAuditLoggingService aals;
 
@@ -75,7 +74,6 @@ public class EntityConfigDownloadServiceImpl extends AdminDownloadService {
 		super.init();
 
 		edm = ManagerLocator.getInstance().getManager(EntityDefinitionManager.class);
-		evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 		ds = ServiceRegistry.getRegistry().getService(DefinitionService.class);
 		aals = ServiceRegistry.getRegistry().getService(AdminAuditLoggingService.class);
 	}
@@ -282,6 +280,7 @@ public class EntityConfigDownloadServiceImpl extends AdminDownloadService {
 			//レスポンス設定
 			DownloadUtil.setCsvResponseHeader(resp, fileName, encode);
 
+			EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 			int i = 1;
 			for (String defName : defNames) {
 				//EntityViewの取得

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/entityexplorer/EntityExplorerServiceImpl.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/tools/rpc/entityexplorer/EntityExplorerServiceImpl.java
@@ -100,11 +100,10 @@ public class EntityExplorerServiceImpl extends XsrfProtectedServiceServlet imple
 	/** シリアルバージョンNo */
 	private static final long serialVersionUID = -3459617043325559477L;
 
-	private static final String USER_ENTITY = "mtp.auth.User";
+//	private static final String USER_ENTITY = "mtp.auth.User";
 
 	private EntityManager em = AdminEntityManager.getInstance();
 	private EntityDefinitionManager edm = ManagerLocator.getInstance().getManager(EntityDefinitionManager.class);
-	private EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 	private EntityService ehs = ServiceRegistry.getRegistry().getService(EntityService.class);
 	private FulltextSearchManager fsm = ManagerLocator.getInstance().getManager(FulltextSearchManager.class);
 	private RdbAdapter rdb = ServiceRegistry.getRegistry().getService(RdbAdapterService.class).getRdbAdapter();
@@ -197,6 +196,7 @@ public class EntityExplorerServiceImpl extends XsrfProtectedServiceServlet imple
 				List<MetaDataEntryInfo> entityList = ehs.list();
 
 				EntityContext ec = EntityContext.getCurrentContext();
+				EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
 
 				List<EntityViewInfo> infoList = new ArrayList<>();
 				for (MetaDataEntryInfo entryInfo : entityList) {
@@ -283,6 +283,8 @@ public class EntityExplorerServiceImpl extends XsrfProtectedServiceServlet imple
 	}
 
 	private void convertNode(SimpleEntityTreeNode entityNode, MetaTreeNode metaNode, boolean isGetDataCount) {
+		EntityViewManager evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
+
 		entityNode.setPath(metaNode.getPath());
 		entityNode.setName(metaNode.getName());
 //		entityNode.setContextPath(metaNode.getContextPath());


### PR DESCRIPTION
フィールドに定義された画面系クラス（Manager、Service）を利用箇所で宣言する形に変更
Entityの表示名更新時、メニューの更新処理をControllerに移動