### PR TITLE
gem、検索結果の表示行数の最大値制御を削除

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/mtp/view/generic/element/section/SearchResultSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/view/generic/element/section/SearchResultSection.java
@@ -85,7 +85,6 @@ public class SearchResultSection extends Section {
 			inputType=InputType.NUMBER,
 			rangeCheck=true,
 			minRange=0,
-			maxRange=200,
 			displayOrder=200,
 			description="検索結果の一覧に表示する件数を指定します。",
 			descriptionKey="generic_element_section_SearchResultSection_dispRowCountDescriptionKey"


### PR DESCRIPTION
https://github.com/ISID/iPLAss/issues/1122 対応