### PR TITLE
クラスタ構成時にメタデータの更新が反映されないケースがある（3.1）

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/impl/cache/store/builtin/SyncServerCacheStoreFactory.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/cache/store/builtin/SyncServerCacheStoreFactory.java
@@ -73,7 +73,7 @@ public class SyncServerCacheStoreFactory extends AbstractBuiltinCacheStoreFactor
 	public void setNoClusterEventOnPut(boolean noClusterEventOnPut) {
 		this.noClusterEventOnPut = noClusterEventOnPut;
 	}
-	
+
 	public SyncServerCacheEventListener getListener() {
 		return listener;
 	}
@@ -152,30 +152,48 @@ public class SyncServerCacheStoreFactory extends AbstractBuiltinCacheStoreFactor
 						if (msg.getEventName().startsWith(CLUSTER_EVENT_NAME_MARK_DIRTY)) {
 							Object key = cacheKeyResolver.toCacheKey(msg.getParameter(CLUSTER_MESSAGE_CACHE_KEY));
 							Object[] index = null;
+							String[] indexValueList = new String[getIndexCount()];
 							if (getIndexCount() > 0) {
 								index = new Object[getIndexCount()];
 								for (int i = 0; i < index.length; i++) {
 									String iVal = msg.getParameter(CLUSTER_MESSAGE_INDEX_PREFIX + i);
+									indexValueList[i] = iVal;
 									if (iVal != null) {
 										index[i] = cacheIndexResolver.get(i).toCacheKey(iVal);
 									}
 								}
 							}
+
 							CacheEntry entry = new CacheEntry(key, null, 0, index);
+							List<CacheEventListener> cacheEventListenerList = wrapped.getListeners();
+
 							wrapped.remove(key);
-							List<CacheEventListener> ls = wrapped.getListeners();
-							if (ls.size() > 0) {
-								CacheInvalidateEvent e = new CacheInvalidateEvent(entry);
-								for (CacheEventListener l: wrapped.getListeners()) {
-									l.invalidated(e);
-								}
-							}
-							if (listener != null) {
-								listener.markDirty(namespace, entry);
-							}
+							notifyRemoveCache(entry, cacheEventListenerList, listener);
+
 							if (logger.isDebugEnabled()) {
 								logger.debug("remove cache entry by cluster message.namespace=" + namespace + ", key=" + key);
 							}
+
+							// ネガティブキャッシュ削除
+							for (int i = 0; i < indexValueList.length; i++) {
+								String indexValue = indexValueList[i];
+								if (null != indexValue) {
+									// インデックス検索を実施する。複数キャッシュを許容している可能性があるので、List 検索する
+									List<CacheEntry> cacheEntryList = wrapped.getListByIndex(i, indexValue);
+									if (null != cacheEntryList) {
+										for (CacheEntry cacheEntry : cacheEntryList) {
+											if (null != cacheEntry && cacheEntry.getKey() instanceof NullKey) {
+												// 対象キャッシュがネガティブキャッシュの場合は削除
+												wrapped.remove(cacheEntry);
+												notifyRemoveCache(cacheEntry, cacheEventListenerList, listener);
+												logger.debug("remove negative cache entry by cluster message.namespace={}, key={}, indexKey={}, indexValue={}, negativeCacheKey={}",
+														namespace, key, i, indexValue, cacheEntry.getKey());
+											}
+										}
+									}
+								}
+							}
+
 						} else if (msg.getEventName().startsWith(CLUSTER_EVENT_NAME_REMOVE_BY_INDEX)) {
 							int indexKey = Integer.parseInt(msg.getParameter(CLUSTER_MESSAGE_INDEX_KEY));
 							String iValStr = msg.getParameter(CLUSTER_MESSAGE_INDEX_VALUE);
@@ -196,8 +214,28 @@ public class SyncServerCacheStoreFactory extends AbstractBuiltinCacheStoreFactor
 							}
 						}
 					}
+
+					/**
+					 * キャッシュエントリ削除の通知
+					 * @param entry 削除対象のキャッシュエントリ
+					 * @param cacheEventListenerList CacheStoreが管理しているキャッシュイベントリスナ
+					 * @param syncServerCacheEventListener SyncServerCacheStoreFactoryで管理しているキャッシュイベントリスナ
+					 */
+					private void notifyRemoveCache(CacheEntry entry, List<CacheEventListener> cacheEventListenerList,
+							SyncServerCacheEventListener syncServerCacheEventListener) {
+
+						if (cacheEventListenerList.size() > 0) {
+							CacheInvalidateEvent e = new CacheInvalidateEvent(entry);
+							for (CacheEventListener l : cacheEventListenerList) {
+								l.invalidated(e);
+							}
+						}
+						if (syncServerCacheEventListener != null) {
+							syncServerCacheEventListener.markDirty(namespace, entry);
+						}
+					}
 			};
-			
+
 			ServiceRegistry.getRegistry().getService(ClusterService.class).registerListener(
 					new String[]{eventNameMarkDirty, eventNameClearAll, eventNameRemoveByIndex}, cel);
 		}
@@ -322,12 +360,12 @@ public class SyncServerCacheStoreFactory extends AbstractBuiltinCacheStoreFactor
 			return SyncServerCacheStoreFactory.this;
 		}
 
-//		@Override
-//		public void invalidate(CacheEntry entry) {
-//			wrapped.invalidate(entry);
-//			sendByKeyEvent(entry);
-//		}
-//
+		//		@Override
+		//		public void invalidate(CacheEntry entry) {
+		//			wrapped.invalidate(entry);
+		//			sendByKeyEvent(entry);
+		//		}
+		//
 		@Override
 		public List<CacheEntry> removeByIndex(int indexKey, Object indexValue) {
 			List<CacheEntry> ret = wrapped.removeByIndex(indexKey, indexValue);
@@ -340,7 +378,7 @@ public class SyncServerCacheStoreFactory extends AbstractBuiltinCacheStoreFactor
 			ServiceRegistry.getRegistry().getService(ClusterService.class).sendMessage(msg);
 			return ret;
 		}
-		
+
 		@Override
 		public int getSize() {
 			return wrapped.getSize();


### PR DESCRIPTION
- インデックスで検索したキャッシュ中のネガティブキャッシュを削除する処理を追加