### PR TITLE
WebAPI、アップロード可能なmimeTypeを指定可能にする

### DIFF
--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/WebApiService.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/WebApiService.java
@@ -23,7 +23,9 @@ package org.iplass.mtp.impl.webapi;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
+import org.apache.poi.util.StringUtil;
 import org.iplass.mtp.ManagerLocator;
 import org.iplass.mtp.definition.TypedDefinitionManager;
 import org.iplass.mtp.impl.definition.AbstractTypedMetaDataService;
@@ -62,7 +64,7 @@ public class WebApiService extends AbstractTypedMetaDataService<MetaWebApi, WebA
 	private boolean writeEncodedFilenameInBinaryApi;
 	private String unescapeFilenameCharacterInBinaryApi;
 	/** バイナリファイルアップロード時に受け入れ可能な MIME Type 正規表現パターン */
-	private String binaryUploadAcceptMimeTypesPattern;
+	private Pattern acceptMimeTypesPatternInBinaryApi;
 
 	public static String getFixedPath() {
 		return WEB_API_META_PATH;
@@ -92,7 +94,11 @@ public class WebApiService extends AbstractTypedMetaDataService<MetaWebApi, WebA
 		writeEncodedFilenameInBinaryApi = config.getValue("writeEncodedFilenameInBinaryApi", Boolean.class,
 				Boolean.FALSE);
 		unescapeFilenameCharacterInBinaryApi = config.getValue("unescapeFilenameCharacterInBinaryApi");
-		binaryUploadAcceptMimeTypesPattern = config.getValue("binaryUploadAcceptMimeTypesPattern");
+
+		String acceptMimeTypesPatternInBinaryApi = config.getValue("acceptMimeTypesPatternInBinaryApi");
+		this.acceptMimeTypesPatternInBinaryApi = StringUtil.isNotBlank(acceptMimeTypesPatternInBinaryApi)
+				? Pattern.compile(acceptMimeTypesPatternInBinaryApi)
+				: null;
 	}
 
 	public boolean isEnableDefinitionApi() {
@@ -115,8 +121,8 @@ public class WebApiService extends AbstractTypedMetaDataService<MetaWebApi, WebA
 	 * バイナリファイルアップロード時に受け入れ可能な MIME Type 正規表現パターンを取得する
 	 * @return バイナリファイルアップロード時に受け入れ可能な MIME Type 正規表現パターン
 	 */
-	public String getBinaryUploadAcceptMimeTypesPattern() {
-		return binaryUploadAcceptMimeTypesPattern;
+	public Pattern getAcceptMimeTypesPatternInBinaryApi() {
+		return acceptMimeTypesPatternInBinaryApi;
 	}
 
 	@Deprecated

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/WebApiService.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/WebApiService.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2017 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -61,15 +61,19 @@ public class WebApiService extends AbstractTypedMetaDataService<MetaWebApi, WebA
 	private boolean enableBinaryApi;
 	private boolean writeEncodedFilenameInBinaryApi;
 	private String unescapeFilenameCharacterInBinaryApi;
+	/** バイナリファイルアップロード時に受け入れ可能な MIME Type 正規表現パターン */
+	private String binaryUploadAcceptMimeTypesPattern;
 
 	public static String getFixedPath() {
 		return WEB_API_META_PATH;
 	}
 
+	@Override
 	public void destroy() {
 
 	}
 
+	@Override
 	@SuppressWarnings("unchecked")
 	public void init(Config config) {
 		statusMap = new HashMap<>();
@@ -88,6 +92,7 @@ public class WebApiService extends AbstractTypedMetaDataService<MetaWebApi, WebA
 		writeEncodedFilenameInBinaryApi = config.getValue("writeEncodedFilenameInBinaryApi", Boolean.class,
 				Boolean.FALSE);
 		unescapeFilenameCharacterInBinaryApi = config.getValue("unescapeFilenameCharacterInBinaryApi");
+		binaryUploadAcceptMimeTypesPattern = config.getValue("binaryUploadAcceptMimeTypesPattern");
 	}
 
 	public boolean isEnableDefinitionApi() {
@@ -104,6 +109,14 @@ public class WebApiService extends AbstractTypedMetaDataService<MetaWebApi, WebA
 
 	public String getUnescapeFilenameCharacterInBinaryApi() {
 		return unescapeFilenameCharacterInBinaryApi;
+	}
+
+	/**
+	 * バイナリファイルアップロード時に受け入れ可能な MIME Type 正規表現パターンを取得する
+	 * @return バイナリファイルアップロード時に受け入れ可能な MIME Type 正規表現パターン
+	 */
+	public String getBinaryUploadAcceptMimeTypesPattern() {
+		return binaryUploadAcceptMimeTypesPattern;
 	}
 
 	@Deprecated

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/command/binary/BinaryCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/command/binary/BinaryCommand.java
@@ -206,7 +206,7 @@ public final class BinaryCommand implements Command, Constants {
 		WebApiService service = ServiceRegistry.getRegistry().getService(WebApiService.class);
 
 		if (StringUtil.isNotBlank(service.getBinaryUploadAcceptMimeTypesPattern())) {
-			// プロパティエディタに設定が無く、GemConfigServiceの受け入れ許可設定が存在する場合は、GemConfigService の設定で許可設定を行う
+			// WebApiServiceの受け入れ許可設定が存在する場合は、WebApiService の設定で許可設定を行う
 			isAccept = Pattern.compile(service.getBinaryUploadAcceptMimeTypesPattern()).matcher(type).matches();
 		}
 		// else {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/command/binary/BinaryCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/command/binary/BinaryCommand.java
@@ -23,7 +23,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.regex.Pattern;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -43,7 +42,6 @@ import org.iplass.mtp.impl.definition.DefinitionService;
 import org.iplass.mtp.impl.webapi.WebApiService;
 import org.iplass.mtp.impl.webapi.command.Constants;
 import org.iplass.mtp.spi.ServiceRegistry;
-import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.web.WebRequestConstants;
 import org.iplass.mtp.webapi.WebApiRequestConstants;
 import org.iplass.mtp.webapi.definition.MethodType;
@@ -205,9 +203,9 @@ public final class BinaryCommand implements Command, Constants {
 
 		WebApiService service = ServiceRegistry.getRegistry().getService(WebApiService.class);
 
-		if (StringUtil.isNotBlank(service.getBinaryUploadAcceptMimeTypesPattern())) {
+		if (null != service.getAcceptMimeTypesPatternInBinaryApi()) {
 			// WebApiServiceの受け入れ許可設定が存在する場合は、WebApiService の設定で許可設定を行う
-			isAccept = Pattern.compile(service.getBinaryUploadAcceptMimeTypesPattern()).matcher(type).matches();
+			isAccept = service.getAcceptMimeTypesPatternInBinaryApi().matcher(type).matches();
 		}
 		// else {
 		// // WebApiService に設定が無い場合はチェックしない

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -492,7 +492,7 @@
 
 		<!-- バイナリファイルアップロード受け入れ可能な MIME Type パターン。正規表現を指定する。 -->
 		<!--
-		<property name="binaryUploadAcceptMimeTypesPattern" value="^(image/.*|application/pdf|text/csv)$" />
+		<property name="acceptMimeTypesPatternInBinaryApi" value="^(image/.*|application/pdf|text/csv)$" />
 		-->
 
 		<property name="xRequestedWithMap">

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -486,7 +486,7 @@
 	<service>
 		<interface>org.iplass.mtp.impl.webapi.WebApiService</interface>
 		<property name="enableDefinitionApi" value="false" />
-		<property name="enableBinaryApi" value="true" />
+		<property name="enableBinaryApi" value="false" />
 		<property name="writeEncodedFilenameInBinaryApi" value="false" />
 		<property name="unescapeFilenameCharacterInBinaryApi" value="-._~" />
 

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -492,7 +492,7 @@
 
 		<!-- バイナリファイルアップロード受け入れ可能な MIME Type パターン。正規表現を指定する。 -->
 		<!--
-		property name="binaryUploadAcceptMimeTypesPattern" value="^(image/.*|application/pdf|text/csv)$" />
+		<property name="binaryUploadAcceptMimeTypesPattern" value="^(image/.*|application/pdf|text/csv)$" />
 		-->
 
 		<property name="xRequestedWithMap">

--- a/iplass-web/src/main/resources/mtp-web-service-config.xml
+++ b/iplass-web/src/main/resources/mtp-web-service-config.xml
@@ -486,9 +486,14 @@
 	<service>
 		<interface>org.iplass.mtp.impl.webapi.WebApiService</interface>
 		<property name="enableDefinitionApi" value="false" />
-		<property name="enableBinaryApi" value="false" />
+		<property name="enableBinaryApi" value="true" />
 		<property name="writeEncodedFilenameInBinaryApi" value="false" />
 		<property name="unescapeFilenameCharacterInBinaryApi" value="-._~" />
+
+		<!-- バイナリファイルアップロード受け入れ可能な MIME Type パターン。正規表現を指定する。 -->
+		<!--
+		property name="binaryUploadAcceptMimeTypesPattern" value="^(image/.*|application/pdf|text/csv)$" />
+		-->
 
 		<property name="xRequestedWithMap">
 			<property name="X-Requested-With" value="XMLHttpRequest" />


### PR DESCRIPTION
- WebApiService にバイナリアップロード受け入れ可能なMIME Typeパターンを追加
- WebAPI ファイルアップロード時にMIME Typeを判別し、受け入れ可否を判定する