### PR TITLE
gem、バイナリプロパティ更新時のmimeTypeチェックの改善

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
@@ -26,8 +26,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.apache.poi.util.StringUtil;
 import org.iplass.gem.AutoGenerateSetting.DisplayPosition;
 import org.iplass.mtp.entity.Entity;
 import org.iplass.mtp.spi.Config;
@@ -125,7 +127,7 @@ public class GemConfigService implements Service {
 	private List<BinaryDownloadLoggingTargetProperty> binaryDownloadLoggingTargetProperty;
 
 	/** エンティティのバイナリプロパティにアップロード受け入れ可能な MIME Types  正規表現パターン */
-	private String binaryUploadAcceptMimeTypesPattern;
+	private Pattern binaryUploadAcceptMimeTypesPattern;
 
 	/** カラー */
 	private List<ImageColorSetting> imageColors;
@@ -151,7 +153,11 @@ public class GemConfigService implements Service {
 	@Override
 	public void init(Config config) {
 		binaryDownloadLoggingTargetProperty = config.getValues("binaryDownloadLoggingTargetProperty", BinaryDownloadLoggingTargetProperty.class);
-		binaryUploadAcceptMimeTypesPattern = config.getValue("binaryUploadAcceptMimeTypesPattern");
+		String binaryUploadAcceptMimeTypesPattern = config.getValue("binaryUploadAcceptMimeTypesPattern");
+		this.binaryUploadAcceptMimeTypesPattern = StringUtil.isNotBlank(binaryUploadAcceptMimeTypesPattern)
+				? Pattern.compile(binaryUploadAcceptMimeTypesPattern)
+				: null;
+
 		imageColors = config.getValues("imageColors", ImageColorSetting.class);
 		loadWithReference = Boolean.valueOf(config.getValue("loadWithReference"));
 		formatNumberWithComma = Boolean.valueOf(config.getValue("formatNumberWithComma"));
@@ -446,7 +452,7 @@ public class GemConfigService implements Service {
 	 * エンティティのバイナリプロパティにアップロード受け入れ可能なMIME Types 正規表現パターンを取得します。
 	 * @return エンティティのバイナリプロパティにアップロード可能なMIME Types 正規表現パターン
 	 */
-	public String getBinaryUploadAcceptMimeTypesPattern() {
+	public Pattern getBinaryUploadAcceptMimeTypesPattern() {
 		return binaryUploadAcceptMimeTypesPattern;
 	}
 

--- a/iplass-gem/src/main/java/org/iplass/gem/command/binary/UploadCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/binary/UploadCommand.java
@@ -22,9 +22,7 @@ package org.iplass.gem.command.binary;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.util.List;
 import java.util.Stack;
-import java.util.regex.Pattern;
 
 import org.iplass.gem.GemConfigService;
 import org.iplass.gem.command.Constants;
@@ -40,21 +38,14 @@ import org.iplass.mtp.command.annotation.action.ActionMapping;
 import org.iplass.mtp.command.annotation.action.Result;
 import org.iplass.mtp.command.annotation.action.Result.Type;
 import org.iplass.mtp.entity.BinaryReference;
+import org.iplass.mtp.impl.view.generic.FormViewRuntimeUtil;
+import org.iplass.mtp.impl.view.generic.editor.MetaBinaryPropertyEditor.BinaryPropertyEditorRuntime;
 import org.iplass.mtp.impl.web.token.TokenStore;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.transaction.TransactionManager;
 import org.iplass.mtp.transaction.TransactionStatus;
 import org.iplass.mtp.util.StringUtil;
-import org.iplass.mtp.view.generic.DetailFormView;
-import org.iplass.mtp.view.generic.EntityView;
-import org.iplass.mtp.view.generic.EntityViewManager;
-import org.iplass.mtp.view.generic.editor.BinaryPropertyEditor;
-import org.iplass.mtp.view.generic.editor.PropertyEditor;
-import org.iplass.mtp.view.generic.element.Element;
-import org.iplass.mtp.view.generic.element.property.PropertyItem;
-import org.iplass.mtp.view.generic.element.section.DefaultSection;
-import org.iplass.mtp.view.generic.element.section.Section;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,8 +61,6 @@ import org.slf4j.LoggerFactory;
 @CommandClass(name="gem/binary/UploadCommand", displayName="アップロード")
 public final class UploadCommand implements Command {
 	private static Logger logger = LoggerFactory.getLogger(UploadCommand.class);
-	/** デフォルトビュー名 */
-	private static final String DEFAULT_VIEW_NAME = "DEFAULT";
 
 	public static final String ACTION_NAME = "gem/binary/upload";
 
@@ -90,18 +79,19 @@ public final class UploadCommand implements Command {
 		}
 
 		// プロパティエディタを取得する情報をリクエストから取得
-		String viewName = request.getParam(Constants.VIEW_NAME);
 		String defName = request.getParam(Constants.DEF_NAME);
+		String viewName = request.getParam(Constants.VIEW_NAME);
 		String propName = request.getParam(Constants.PROP_NAME);
 
 		// プロパティエディタを取得
-		BinaryPropertyEditor editor = getBinaryPropertyEditor(defName, propName, viewName);
+		BinaryPropertyEditorRuntime editorRuntime = FormViewRuntimeUtil.getPropertyEditorRuntime(defName, viewName, propName,
+				BinaryPropertyEditorRuntime.class);
 
 		try {
 			UploadFileHandle file = request.getParamAsFile("filePath");
 			request.setAttribute("contentType", "application/xml");
 
-			if (file != null && isRejectMimeTypes(file.getType(), editor)) {
+			if (file != null && isRejectMimeTypes(file.getType(), editorRuntime)) {
 				logger.error("File upload rejected. fileName = {}, fileType = {}, fileSize = {}.", file.getFileName(), file.getType(),
 						file.getSize());
 				request.setAttribute(Constants.CMD_RSLT_STREAM,
@@ -144,21 +134,21 @@ public final class UploadCommand implements Command {
 	 * アップロードファイルは拒否される MIME Type（メディアタイプ）であるか確認する
 	 *
 	 * @param type MIME Type（メディアタイプ）
-	 * @param editor 当該プロパティのプロパティエディタ
+	 * @param editorRuntime 当該プロパティのプロパティエディタランタイム
 	 * @return 判定結果（拒否される場合 true ）
 	 */
-	private boolean isRejectMimeTypes(String type, BinaryPropertyEditor editor) {
+	private boolean isRejectMimeTypes(String type, BinaryPropertyEditorRuntime editorRuntime) {
 		boolean isAccept = true;
 
 		GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
 
-		if (null != editor && StringUtil.isNotBlank(editor.getUploadAcceptMimeTypesPattern())) {
+		if (null != editorRuntime && null != editorRuntime.getUploadAcceptMimeTypesPattern()) {
 			// プロパティエディタに許可する MIME Type が指定されている場合は、プロパティエディタを優先する
-			isAccept = Pattern.compile(editor.getUploadAcceptMimeTypesPattern()).matcher(type).matches();
+			isAccept = editorRuntime.getUploadAcceptMimeTypesPattern().matcher(type).matches();
 
-		} else if (StringUtil.isNotBlank(service.getBinaryUploadAcceptMimeTypesPattern())) {
+		} else if (null != service.getBinaryUploadAcceptMimeTypesPattern()) {
 			// プロパティエディタに設定が無く、GemConfigServiceの受け入れ許可設定が存在する場合は、GemConfigService の設定で許可設定を行う
-			isAccept = Pattern.compile(service.getBinaryUploadAcceptMimeTypesPattern()).matcher(type).matches();
+			isAccept = service.getBinaryUploadAcceptMimeTypesPattern().matcher(type).matches();
 		}
 		// else {
 		// // プロパティエディタ、GemServiceConfig に設定が無い場合はチェックしない
@@ -166,64 +156,6 @@ public final class UploadCommand implements Command {
 
 		// 拒否判定の為、accept を反転する
 		return !isAccept;
-	}
-
-	/**
-	 * エンティティのビュー定義を取得する
-	 * @param defName エンティティ定義名
-	 * @param viewName エンティティビュー名
-	 * @return エンティティビュー定義
-	 */
-	private DetailFormView getDetailFormView(String defName, String viewName) {
-		EntityViewManager manager = ManagerLocator.manager(EntityViewManager.class);
-		EntityView entityViewDef = manager.get(defName);
-
-		// エンティティビュー定義が無い場合は null 返却
-		if (null == entityViewDef) {
-			return null;
-		}
-
-		if (DEFAULT_VIEW_NAME.equals(viewName) || StringUtil.isEmpty(viewName)) {
-			// ビュー名が "DEFUALT" もしくは、view名が無い場合はデフォルトを取得する
-			return entityViewDef.getDefaultDetailFormView();
-		}
-		// ビュー名を取得する
-		return entityViewDef.getDetailFormView(viewName);
-	}
-
-	/**
-	 * 指定されたプロパティのバイナリプロパティエディターを取得する
-	 * @param defName エンティティ定義名
-	 * @param propName プロパティ名
-	 * @param viewName ビュー名
-	 * @return バイナリプロパティエディター
-	 */
-	private BinaryPropertyEditor getBinaryPropertyEditor(String defName, String propName, String viewName) {
-		DetailFormView view = getDetailFormView(defName, viewName);
-
-		if (view == null || propName == null) {
-			return null;
-		}
-
-		// TODO ビュー中に複数の同一プロパティが存在していた場合、正しく取得することができない。
-		List<Section> sections = view.getSections();
-		for (Section section : sections) {
-			if (section instanceof DefaultSection) {
-				for (Element element : ((DefaultSection) section).getElements()) {
-					if (element instanceof PropertyItem) {
-						if (propName.equals(((PropertyItem) element).getPropertyName())) {
-							PropertyEditor editor = ((PropertyItem) element).getEditor();
-							if (editor instanceof BinaryPropertyEditor) {
-								return (BinaryPropertyEditor) editor;
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// 定義が無い場合は null を返却
-		return null;
 	}
 
 	/**

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/FormViewRuntime.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/FormViewRuntime.java
@@ -77,4 +77,11 @@ public class FormViewRuntime {
 		return metaData;
 	}
 
+	/**
+	 * FormView セクションランタイムリストを取得します。
+	 * @return セクションランタイムリスト
+	 */
+	public List<SectionRuntime> getSections() {
+		return sections;
+	}
 }

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/FormViewRuntimeUtil.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/FormViewRuntimeUtil.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.view.generic;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor.PropertyEditorRuntime;
+import org.iplass.mtp.impl.view.generic.element.section.HasSectionPropertyRuntimeMap;
+import org.iplass.mtp.impl.view.generic.element.section.MetaDefaultSection.DefaultSectionRuntime;
+import org.iplass.mtp.impl.view.generic.element.section.MetaReferenceSection.ReferenceSectionRuntime;
+import org.iplass.mtp.impl.view.generic.element.section.SectionRuntime;
+import org.iplass.mtp.spi.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FormViewRuntime に関連するユーティリティクラス
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class FormViewRuntimeUtil {
+	/** ロガー */
+	private static Logger LOG = LoggerFactory.getLogger(FormViewRuntimeUtil.class);
+
+	// NOTE (default)のビュー名は空文字 "" になることを実行確認した
+	/** ビュー名が指定されていない場合のデフォルト値 */
+	private static final String VIEW_DEFAULT_NAME = "";
+
+	/**
+	 * プライベートコンストラクタ
+	 */
+	private FormViewRuntimeUtil() {
+	}
+
+	/**
+	 * エンティティのビュー定義を取得する
+	 *
+	 * @param <T> FormViewRuntimeクラス
+	 * @param defName エンティティ定義名
+	 * @param viewName エンティティビュー名
+	 * @param runtimeClass FormViewRuntimeクラス
+	 * @return エンティティビュー定義
+	 */
+	@SuppressWarnings("unchecked")
+	public static <T extends FormViewRuntime> T getFormViewRuntime(String defName, String viewName, Class<T> runtimeClass) {
+		EntityViewService service = ServiceRegistry.getRegistry().getService(EntityViewService.class);
+		EntityViewRuntime entityViewRuntime = service.getRuntimeByName(defName);
+
+		if (null != entityViewRuntime) {
+			// エンティティビュー名を非null化
+			String nonNullViewName = Optional.ofNullable(viewName).orElse(VIEW_DEFAULT_NAME);
+
+			for (FormViewRuntime viewRuntime : entityViewRuntime.getFormViews()) {
+				if (runtimeClass.isAssignableFrom(viewRuntime.getClass())
+						&& nonNullViewName.equals(viewRuntime.getMetaData().getName())) {
+					return (T) viewRuntime;
+				}
+			}
+		}
+
+		LOG.warn("FormViewRuntime was not found. entityName = {}, viewName = {}, runtimeClass = {}", defName, viewName,
+				runtimeClass);
+
+		return null;
+	}
+
+	/**
+	 * 指定されたプロパティのプロパティエディタランタイムを取得する
+	 * @param <T> プロパティエディタランタイムクラス
+	 * @param viewRuntime FormViewランタイム
+	 * @param propName プロパティ名
+	 * @param runtimeClass プロパティエディタランタイムクラス
+	 * @return プロパティエディタランタイム
+	 */
+	public static <T extends PropertyEditorRuntime> T getPropertyEditorRuntime(DetailFormViewRuntime viewRuntime, String propName,
+			Class<T> runtimeClass) {
+		if (null == viewRuntime || null == propName) {
+			return null;
+		}
+
+		// プロパティ名に "." が存在していた場合、ネストプロパティとして判断する
+		Function<SectionRuntime, Boolean> isSectionRuntimeType = propName.contains(".")
+				// ネストプロパティの場合は、リファレンスセクションの判定を実施
+				? FormViewRuntimeUtil::isReferenceSectionRuntime
+				// 通常プロパティの場合は、デフォルトセクションの判定を実施
+				: FormViewRuntimeUtil::isDefaultSectionRuntime;
+
+		// TODO ビュー中に複数の同一プロパティが存在していた場合、正しく取得することができない。
+		List<SectionRuntime> sections = viewRuntime.getSections();
+		for (SectionRuntime section : sections) {
+			if (isSectionRuntimeType.apply(section)) {
+				T propertyEditorRuntime = ((HasSectionPropertyRuntimeMap) section).getPropertyEditorRuntime(propName, runtimeClass);
+				if (null != propertyEditorRuntime) {
+					// ネストプロパティではなく、プロパティエディタランタイムが指定された型の場合は、値を返却する
+					return propertyEditorRuntime;
+				}
+			}
+		}
+
+		// 警告ログ出力
+		LOG.warn("Property does not exist or PropertyEditor is not defined. viewRuntime = {}, propName = {}, runtimeClass = {}",
+				viewRuntime.getMetaData().getName(), propName, runtimeClass);
+
+		// 定義が無い場合は null を返却
+		return null;
+	}
+
+	/**
+	 * 指定されたプロパティのプロパティエディタランタイムを取得する
+	 * @param <T> プロパティエディタランタイムクラス
+	 * @param defName エンティティ名
+	 * @param viewName エンティティビュー名
+	 * @param propName プロパティ名
+	 * @param runtimeClass プロパティエディタランタイムクラス
+	 * @return プロパティエディタランタイム
+	 */
+	public static <T extends PropertyEditorRuntime> T getPropertyEditorRuntime(String defName, String viewName, String propName,
+			Class<T> runtimeClass) {
+		DetailFormViewRuntime viewRuntime = getFormViewRuntime(defName, viewName, DetailFormViewRuntime.class);
+		return getPropertyEditorRuntime(viewRuntime, propName, runtimeClass);
+	}
+
+	/**
+	 * デフォルトセクションの判定を実施する。
+	 *
+	 * <p>
+	 * 本メソッドで判定する SecrionRuntime は HasSectionPropertyRuntimeMap を実装する必要がある。
+	 * </p>
+	 *
+	 * @param runtime SectionRuntimeインスタンス
+	 * @return 想定したクラスであればtrue
+	 */
+	private static boolean isDefaultSectionRuntime(SectionRuntime runtime) {
+		return runtime instanceof DefaultSectionRuntime;
+	}
+
+	/**
+	 * リファレンスセクションの判定を実施する。
+	 *
+	 * <p>
+	 * 本メソッドで判定する SecrionRuntime は HasSectionPropertyRuntimeMap を実装する必要がある。
+	 * </p>
+	 *
+	 * @param runtime SectionRuntimeインスタンス
+	 * @return 想定したクラスであればtrue
+	 */
+	private static boolean isReferenceSectionRuntime(SectionRuntime runtime) {
+		return runtime instanceof ReferenceSectionRuntime;
+	}
+}

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaBinaryPropertyEditor.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaBinaryPropertyEditor.java
@@ -20,11 +20,12 @@
 
 package org.iplass.mtp.impl.view.generic.editor;
 
+import java.util.regex.Pattern;
+
 import org.iplass.mtp.entity.definition.PropertyDefinition;
 import org.iplass.mtp.entity.definition.properties.BinaryProperty;
 import org.iplass.mtp.impl.entity.EntityContext;
 import org.iplass.mtp.impl.entity.EntityHandler;
-import org.iplass.mtp.impl.metadata.MetaDataRuntime;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.impl.view.generic.EntityViewRuntime;
 import org.iplass.mtp.impl.view.generic.FormViewRuntime;
@@ -37,8 +38,8 @@ import org.iplass.mtp.view.generic.editor.PropertyEditor;
  * バイナリ型プロパティエディタのメタデータ
  * @author lis3wg
  */
-public class MetaBinaryPropertyEditor extends MetaPrimitivePropertyEditor {
 
+public class MetaBinaryPropertyEditor extends MetaPrimitivePropertyEditor {
 	/** シリアルバージョンUID */
 	private static final long serialVersionUID = 8428866745088395378L;
 
@@ -85,7 +86,7 @@ public class MetaBinaryPropertyEditor extends MetaPrimitivePropertyEditor {
 	/** Label形式の場合の更新制御 */
 	private boolean updateWithLabelValue = false;
 
-	/** アップロード受け入れ可能な MIME Type 正規表現パターン*/
+	/** アップロード受け入れ可能な MIME Type 正規表現パターン */
 	private String uploadAcceptMimeTypesPattern;
 
 	/**
@@ -366,14 +367,45 @@ public class MetaBinaryPropertyEditor extends MetaPrimitivePropertyEditor {
 	}
 
 	@Override
-	public MetaDataRuntime createRuntime(EntityViewRuntime entityView, FormViewRuntime formView,
+	public BinaryPropertyEditorRuntime createRuntime(EntityViewRuntime entityView, FormViewRuntime formView,
 			MetaPropertyLayout propertyLayout, EntityContext context, EntityHandler eh) {
-		return new PropertyEditorRuntime(entityView, formView, propertyLayout, context, eh) {
-			@Override
-			protected boolean checkPropertyType(PropertyDefinition pd) {
-				return pd == null || pd instanceof BinaryProperty;
-			}
+		return new BinaryPropertyEditorRuntime(entityView, formView, propertyLayout, context, eh);
+	}
 
-		};
+	/**
+	 * バイナリプロパティエディターランタイム
+	 */
+	public class BinaryPropertyEditorRuntime extends PropertyEditorRuntime {
+		/** コンパイル済みアップロード受け入れ可能な MIME Type 正規表現パターン */
+		private Pattern uploadAcceptMimeTypesPattern;
+
+		/**
+		 * コンストラクタ
+		 * @param entityView エンティティビューランタイム
+		 * @param formView FormViewランタイム
+		 * @param propertyLayout プロパティレイアウトメタ情報
+		 * @param context エンティティコンテキスト
+		 * @param eh エンティティハンドラー
+		 */
+		public BinaryPropertyEditorRuntime(EntityViewRuntime entityView, FormViewRuntime formView,
+				MetaPropertyLayout propertyLayout, EntityContext context, EntityHandler eh) {
+			super(entityView, formView, propertyLayout, context, eh);
+			this.uploadAcceptMimeTypesPattern = null != MetaBinaryPropertyEditor.this.uploadAcceptMimeTypesPattern
+					? Pattern.compile(MetaBinaryPropertyEditor.this.uploadAcceptMimeTypesPattern)
+					: null;
+		}
+
+		@Override
+		protected boolean checkPropertyType(PropertyDefinition pd) {
+			return pd == null || pd instanceof BinaryProperty;
+		}
+
+		/**
+		 * コンパイル済みアップロード受け入れ可能な MIME Type 正規表現パターンを取得する
+		 * @return コンパイル済みアップロード受け入れ可能な MIME Type 正規表現パターン
+		 */
+		public Pattern getUploadAcceptMimeTypesPattern() {
+			return uploadAcceptMimeTypesPattern;
+		}
 	}
 }

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaNestProperty.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaNestProperty.java
@@ -31,6 +31,7 @@ import org.iplass.mtp.impl.i18n.I18nUtil;
 import org.iplass.mtp.impl.i18n.MetaLocalizedString;
 import org.iplass.mtp.impl.metadata.MetaData;
 import org.iplass.mtp.impl.util.ObjectUtil;
+import org.iplass.mtp.impl.view.generic.HasEntityProperty;
 import org.iplass.mtp.impl.view.generic.common.MetaAutocompletionSetting;
 import org.iplass.mtp.view.generic.RequiredDisplayType;
 import org.iplass.mtp.view.generic.TextAlign;
@@ -44,7 +45,7 @@ import org.iplass.mtp.view.generic.editor.ReferencePropertyEditor;
  *
  * @author lis3wg
  */
-public class MetaNestProperty implements MetaData {
+public class MetaNestProperty implements MetaData, HasEntityProperty {
 
 	/** SerialVersionUID */
 	private static final long serialVersionUID = -5324754433567181221L;
@@ -108,7 +109,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return プロパティID
 	 */
 	public String getPropertyId() {
-	    return propertyId;
+		return propertyId;
 	}
 
 	/**
@@ -116,7 +117,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param propertyId プロパティID
 	 */
 	public void setPropertyId(String propertyId) {
-	    this.propertyId = propertyId;
+		this.propertyId = propertyId;
 	}
 
 	/**
@@ -124,7 +125,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return 表示名
 	 */
 	public String getDisplayLabel() {
-	    return displayLabel;
+		return displayLabel;
 	}
 
 	/**
@@ -132,7 +133,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param displayLabel 表示名
 	 */
 	public void setDisplayLabel(String displayLabel) {
-	    this.displayLabel = displayLabel;
+		this.displayLabel = displayLabel;
 	}
 
 	/**
@@ -140,7 +141,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return 説明
 	 */
 	public String getDescription() {
-	    return description;
+		return description;
 	}
 
 	/**
@@ -148,7 +149,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param description 説明
 	 */
 	public void setDescription(String description) {
-	    this.description = description;
+		this.description = description;
 	}
 
 	/**
@@ -156,7 +157,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return ツールチップ
 	 */
 	public String getTooltip() {
-	    return tooltip;
+		return tooltip;
 	}
 
 	/**
@@ -164,7 +165,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param tooltip ツールチップ
 	 */
 	public void setTooltip(String tooltip) {
-	    this.tooltip = tooltip;
+		this.tooltip = tooltip;
 	}
 
 	/**
@@ -172,7 +173,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return 列幅
 	 */
 	public int getWidth() {
-	    return width;
+		return width;
 	}
 
 	/**
@@ -180,7 +181,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param width 列幅
 	 */
 	public void setWidth(int width) {
-	    this.width = width;
+		this.width = width;
 	}
 
 	/**
@@ -188,7 +189,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return テキストの配置
 	 */
 	public TextAlign getTextAlign() {
-	    return textAlign;
+		return textAlign;
 	}
 
 	/**
@@ -196,7 +197,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param textAlign テキストの配置
 	 */
 	public void setTextAlign(TextAlign textAlign) {
-	    this.textAlign = textAlign;
+		this.textAlign = textAlign;
 	}
 
 	/**
@@ -204,7 +205,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return 詳細編集非表示設定
 	 */
 	public boolean isHideDetail() {
-	    return hideDetail;
+		return hideDetail;
 	}
 
 	/**
@@ -212,7 +213,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param hideDetail 詳細編集非表示設定
 	 */
 	public void setHideDetail(boolean hideDetail) {
-	    this.hideDetail = hideDetail;
+		this.hideDetail = hideDetail;
 	}
 
 	/**
@@ -220,7 +221,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return 詳細表示非表示設定
 	 */
 	public boolean isHideView() {
-	    return hideView;
+		return hideView;
 	}
 
 	/**
@@ -228,7 +229,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param hideView 詳細表示非表示設定
 	 */
 	public void setHideView(boolean hideView) {
-	    this.hideView = hideView;
+		this.hideView = hideView;
 	}
 
 	/**
@@ -252,7 +253,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return 通常検索で必須条件にする
 	 */
 	public boolean isRequiredNormal() {
-	    return requiredNormal;
+		return requiredNormal;
 	}
 
 	/**
@@ -260,7 +261,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param requiredNormal 通常検索で必須条件にする
 	 */
 	public void setRequiredNormal(boolean requiredNormal) {
-	    this.requiredNormal = requiredNormal;
+		this.requiredNormal = requiredNormal;
 	}
 
 	/**
@@ -268,7 +269,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return 詳細検索で必須条件にする
 	 */
 	public boolean isRequiredDetail() {
-	    return requiredDetail;
+		return requiredDetail;
 	}
 
 	/**
@@ -276,7 +277,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param requiredDetail 詳細検索で必須条件にする
 	 */
 	public void setRequiredDetail(boolean requiredDetail) {
-	    this.requiredDetail = requiredDetail;
+		this.requiredDetail = requiredDetail;
 	}
 
 	/**
@@ -316,7 +317,7 @@ public class MetaNestProperty implements MetaData {
 	 * @return プロパティエディタ
 	 */
 	public MetaPropertyEditor getEditor() {
-	    return editor;
+		return editor;
 	}
 
 	/**
@@ -324,7 +325,7 @@ public class MetaNestProperty implements MetaData {
 	 * @param editor プロパティエディタ
 	 */
 	public void setEditor(MetaPropertyEditor editor) {
-	    this.editor = editor;
+		this.editor = editor;
 	}
 
 	/**

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/HasSectionPropertyRuntimeMap.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/HasSectionPropertyRuntimeMap.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.view.generic.element.section;
+
+import java.util.Map;
+import java.util.Optional;
+
+import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor.PropertyEditorRuntime;
+
+/**
+ * SectionRuntime でプロパティランタイムを管理している場合に付与するインターフェース
+ *
+ * <p>
+ * 本インターフェースは、{@ org.iplass.mtp.impl.view.generic.element.section.SectionRuntime} 実装クラスに実装することを想定している。
+ * 本インターフェースを実装することで、セクション管理しているプロパティランタイムのヘルパー機能をデフォルト実装する。
+ * {@link #getSectionPropertyRuntimeMap()} で取得するプロパティランタイムは、ネストプロパティを意識した形で保持している必要がある。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public interface HasSectionPropertyRuntimeMap {
+	/**
+	 * セクションで保持しているプロパティランタイム情報を取得する。
+	 *
+	 * <p>
+	 * 返却する値のキーは、プロパティ名称とする。
+	 * </p>
+	 *
+	 * @return セクションで保持しているプロパティランタイム情報
+	 */
+	Map<String, SectionPropertyRuntime> getSectionPropertyRuntimeMap();
+
+	/**
+	 * プロパティ名からセクションで保持しているプロパティランタイムを取得する。
+	 *
+	 * <p>
+	 * 引数のプロパティ名について、ネストプロパティの場合は <code>parent[0].nest</code> といった形で指定されることを想定している。
+	 * </p>
+	 *
+	 * @param propertyName プロパティ名
+	 * @return プロパティランタイム
+	 */
+	default SectionPropertyRuntime getSectionPropertyRuntime(String propertyName) {
+		boolean isNestProperty = propertyName.contains(".");
+		String parentPropertyKey = isNestProperty ? propertyName.substring(0, propertyName.indexOf('[')) : propertyName;
+		String nestPropertyKey = isNestProperty ? propertyName.substring(propertyName.indexOf('.') + 1) : null;
+
+		SectionPropertyRuntime parent = getSectionPropertyRuntimeMap().get(parentPropertyKey);
+
+		return isNestProperty && null != parent && parent instanceof SectionNestPropertyRuntime
+				// ネストプロパティの場合は、取得したプロパティのネストランタイムから取得し、返却する
+				? ((SectionNestPropertyRuntime) parent).getNest().get(nestPropertyKey)
+				// 通常プロパティの場合は、先に取得したプロパティランタイムを返却する
+				: parent;
+	}
+
+	/**
+	 * プロパティエディタランタイムを取得する
+	 * @param propertyName 取得するプロパティ名
+	 * @return プロパティエディタランタイム
+	 */
+	default PropertyEditorRuntime getPropertyEditorRuntime(String propertyName) {
+		return getPropertyEditorRuntime(propertyName, PropertyEditorRuntime.class);
+	}
+
+	/**
+	 * プロパティエディタランタイムを取得する
+	 * @param <T> プロパティエディタランタイムタイプ
+	 * @param propertyName 取得するプロパティ名
+	 * @param clazz プロパティエディタランタイムデータ型
+	 * @return プロパティエディタランタイム
+	 */
+	@SuppressWarnings("unchecked")
+	default <T extends PropertyEditorRuntime> T getPropertyEditorRuntime(String propertyName, Class<T> clazz) {
+		SectionPropertyRuntime property = getSectionPropertyRuntime(propertyName);
+
+		return (T) Optional.ofNullable(property).map(v -> v.getEditor()).filter(v -> clazz.isAssignableFrom(v.getClass()))
+				.orElse(null);
+	}
+}

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaDefaultSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaDefaultSection.java
@@ -565,8 +565,7 @@ public class MetaDefaultSection extends MetaSection {
 
 								// ネストプロパティランタイム管理用インスタンスのビルダーを作成
 								// ネストプロパティの場合は、通常プロパティの element に該当する情報が無いので、設定されない。
-								// TODO propertyLayout#convertName を利用しているが、MetaNestProperty に HasEntityPropertyインターフェース実装が正しいか。
-								String nestPropertyName = propertyLayout.convertName(nest.getPropertyId(), context, nestEh);
+								String nestPropertyName = nest.convertName(nest.getPropertyId(), context, nestEh);
 								SectionPropertyRuntimeBuilder nestBuilder = new SectionPropertyRuntimeBuilder(nestPropertyName);
 
 								if (nestEditor != null) {

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaDefaultSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaDefaultSection.java
@@ -71,7 +71,7 @@ public class MetaDefaultSection extends MetaSection {
 	private static boolean defaultDispBorderInSection;
 
 	static {
-		 // システムプロパティorデフォルトtrueで初期化
+		// システムプロパティorデフォルトtrueで初期化
 		String value = System.getProperty("mtp.generic.dispBorderInSection", "true");
 		defaultDispBorderInSection = Boolean.parseBoolean(value);
 	}
@@ -211,7 +211,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @return リンクを表示するか
 	 */
 	public boolean isShowLink() {
-	    return showLink;
+		return showLink;
 	}
 
 	/**
@@ -219,7 +219,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @param showLink リンクを表示するか
 	 */
 	public void setShowLink(boolean showLink) {
-	    this.showLink = showLink;
+		this.showLink = showLink;
 	}
 
 	/**
@@ -227,7 +227,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @return 詳細編集非表示設定
 	 */
 	public boolean isHideDetail() {
-	    return hideDetail;
+		return hideDetail;
 	}
 
 	/**
@@ -235,7 +235,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @param hideDetail 詳細編集非表示設定
 	 */
 	public void setHideDetail(boolean hideDetail) {
-	    this.hideDetail = hideDetail;
+		this.hideDetail = hideDetail;
 	}
 
 	/**
@@ -243,7 +243,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @return 詳細表示非表示設定
 	 */
 	public boolean isHideView() {
-	    return hideView;
+		return hideView;
 	}
 
 	/**
@@ -251,7 +251,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @param hideView 詳細表示非表示設定
 	 */
 	public void setHideView(boolean hideView) {
-	    this.hideView = hideView;
+		this.hideView = hideView;
 	}
 
 	/**
@@ -259,7 +259,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @return 上部のコンテンツ
 	 */
 	public String getUpperContents() {
-	    return upperContents;
+		return upperContents;
 	}
 
 	/**
@@ -267,7 +267,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @param upperContents 上部のコンテンツ
 	 */
 	public void setUpperContents(String upperContents) {
-	    this.upperContents = upperContents;
+		this.upperContents = upperContents;
 	}
 
 	/**
@@ -275,7 +275,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @return 下部のコンテンツ
 	 */
 	public String getLowerContents() {
-	    return lowerContents;
+		return lowerContents;
 	}
 
 	/**
@@ -283,7 +283,7 @@ public class MetaDefaultSection extends MetaSection {
 	 * @param lowerContents 下部のコンテンツ
 	 */
 	public void setLowerContents(String lowerContents) {
-	    this.lowerContents = lowerContents;
+		this.lowerContents = lowerContents;
 	}
 
 	/**
@@ -510,10 +510,13 @@ public class MetaDefaultSection extends MetaSection {
 	 * ランタイム
 	 * @author lis3wg
 	 */
-	public class DefaultSectionRuntime extends SectionRuntime {
-
+	public class DefaultSectionRuntime extends SectionRuntime implements HasSectionPropertyRuntimeMap {
+		// TODO 要素情報の取得意味が不明
 		/** 要素情報*/
 		private List<ElementRuntime> elements;
+
+		/** セクションに設定されているプロパティ情報。キーはプロパティ名。 */
+		private Map<String, SectionPropertyRuntime> sectionPropertyRuntimeMap = new HashMap<>();
 
 		/**
 		 * コンストラクタ
@@ -529,29 +532,64 @@ public class MetaDefaultSection extends MetaSection {
 			elements = new ArrayList<>();
 			Map<String, GroovyTemplate> customStyleMap = new HashMap<>();
 			for (MetaElement element : metadata.getElements()) {
-				elements.add(element.createRuntime(entityView, formView));
+				ElementRuntime elementRuntime = element.createRuntime(entityView, formView);
+				elements.add(elementRuntime);
 
 				if (element instanceof MetaPropertyLayout) {
 					MetaPropertyLayout propertyLayout = (MetaPropertyLayout)element;
 					MetaPropertyEditor editor = propertyLayout.getEditor();
+
+					// element が MetaPropertyLaytout であれば、propertyRuntime として管理する。
+					// プロパティIDからプロパティ名に変換
+					String propertyName = propertyLayout.convertName(propertyLayout.getPropertyId(), context, eh);
+					// プロパティランタイム管理用インスタンスのビルダーを作成
+					SectionPropertyRuntimeBuilder builder = new SectionPropertyRuntimeBuilder(propertyName);
+					builder.element(elementRuntime);
+
 					if (editor != null) {
 						PropertyEditorRuntime runtime = (PropertyEditorRuntime)editor.createRuntime(entityView, formView, propertyLayout, context, eh);
 						customStyleMap.put(editor.getOutputCustomStyleScriptKey(), runtime.getOutputCustomStyleScript());
 						customStyleMap.put(editor.getInputCustomStyleScriptKey(), runtime.getInputCustomStyleScript());
 
+						// PropertyEditorRuntime を設定
+						builder.editor(runtime);
+
 						if (editor instanceof HasMetaNestProperty) {
+							// ネストプロパティの場合は、ネスト先プロパティの情報を管理する。
+							// ネストエンティティのエンティティハンドラ
+							EntityHandler nestEh = context.getHandlerById(((HasMetaNestProperty) editor).getObjectId());
+							// プロパティ情報に格納するプロパティインスタンス
+							Map<String, SectionPropertyRuntime> nestProperties = new HashMap<>();
 							for (MetaNestProperty nest : ((HasMetaNestProperty)editor).getNestProperties()) {
 								MetaPropertyEditor nestEditor = nest.getEditor();
+
+								// ネストプロパティランタイム管理用インスタンスのビルダーを作成
+								// ネストプロパティの場合は、通常プロパティの element に該当する情報が無いので、設定されない。
+								// TODO propertyLayout#convertName を利用しているが、MetaNestProperty に HasEntityPropertyインターフェース実装が正しいか。
+								String nestPropertyName = propertyLayout.convertName(nest.getPropertyId(), context, nestEh);
+								SectionPropertyRuntimeBuilder nestBuilder = new SectionPropertyRuntimeBuilder(nestPropertyName);
+
 								if (nestEditor != null) {
 									//TODO nest type check
 									PropertyEditorRuntime nestRuntime = (PropertyEditorRuntime)nestEditor.createRuntime(entityView, formView, null, context, eh);
 									customStyleMap.put(nestEditor.getOutputCustomStyleScriptKey(), nestRuntime.getOutputCustomStyleScript());
 									customStyleMap.put(nestEditor.getInputCustomStyleScriptKey(), nestRuntime.getInputCustomStyleScript());
+
+									// PropertyEditorRuntime を設定
+									nestBuilder.editor(nestRuntime);
 								}
+								nestProperties.put(nestPropertyName, nestBuilder.build());
 							}
+
+							// ネストプロパティランタイム情報を、ビルダーに設定
+							builder.nest(nestProperties);
 						}
 					}
+
+					// プロパティランタイムを生成
+					sectionPropertyRuntimeMap.put(propertyName, builder.build());
 				}
+
 				if (element instanceof MetaButton) {
 					MetaButton button = (MetaButton)element;
 					ButtonRuntime runtime = button.createRuntime(entityView, formView);
@@ -592,6 +630,11 @@ public class MetaDefaultSection extends MetaSection {
 			TenantContext tenant = ExecuteContext.getCurrentContext().getTenantContext();
 			return GroovyTemplateCompiler.compile(
 					script, key, (GroovyScriptEngine) tenant.getScriptEngine());
+		}
+
+		@Override
+		public Map<String, SectionPropertyRuntime> getSectionPropertyRuntimeMap() {
+			return sectionPropertyRuntimeMap;
 		}
 	}
 }

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaReferenceSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaReferenceSection.java
@@ -21,7 +21,9 @@
 package org.iplass.mtp.impl.view.generic.element.section;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.iplass.mtp.impl.core.ExecuteContext;
 import org.iplass.mtp.impl.core.TenantContext;
@@ -38,7 +40,10 @@ import org.iplass.mtp.impl.script.template.GroovyTemplateCompiler;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.impl.view.generic.EntityViewRuntime;
 import org.iplass.mtp.impl.view.generic.FormViewRuntime;
+import org.iplass.mtp.impl.view.generic.HasEntityProperty;
 import org.iplass.mtp.impl.view.generic.editor.MetaNestProperty;
+import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor;
+import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor.PropertyEditorRuntime;
 import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.view.generic.editor.NestProperty;
 import org.iplass.mtp.view.generic.element.Element;
@@ -57,7 +62,7 @@ public class MetaReferenceSection extends MetaSection {
 	private static boolean defaultDispBorderInSection;
 
 	static {
-		 // システムプロパティorデフォルトtrueで初期化
+		// システムプロパティorデフォルトtrueで初期化
 		String value = System.getProperty("mtp.generic.dispBorderInSection", "true");
 		defaultDispBorderInSection = Boolean.parseBoolean(value);
 	}
@@ -126,7 +131,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return プロパティID
 	 */
 	public String getPropertyId() {
-	    return propertyId;
+		return propertyId;
 	}
 
 	/**
@@ -134,7 +139,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param propertyId プロパティID
 	 */
 	public void setPropertyId(String propertyId) {
-	    this.propertyId = propertyId;
+		this.propertyId = propertyId;
 	}
 
 	/**
@@ -142,7 +147,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return タイトル
 	 */
 	public String getTitle() {
-	    return title;
+		return title;
 	}
 
 	/**
@@ -150,7 +155,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param title タイトル
 	 */
 	public void setTitle(String title) {
-	    this.title = title;
+		this.title = title;
 	}
 
 	/**
@@ -158,7 +163,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return セクションの展開可否
 	 */
 	public boolean isExpandable() {
-	    return expandable;
+		return expandable;
 	}
 
 	/**
@@ -166,7 +171,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param expandable セクションの展開可否
 	 */
 	public void setExpandable(boolean expandable) {
-	    this.expandable = expandable;
+		this.expandable = expandable;
 	}
 
 	/**
@@ -174,7 +179,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return id
 	 */
 	public String getId() {
-	    return id;
+		return id;
 	}
 
 	/**
@@ -182,7 +187,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param id id
 	 */
 	public void setId(String id) {
-	    this.id = id;
+		this.id = id;
 	}
 
 	/**
@@ -190,7 +195,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return クラス名
 	 */
 	public String getStyle() {
-	    return style;
+		return style;
 	}
 
 	/**
@@ -198,7 +203,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param style クラス名
 	 */
 	public void setStyle(String style) {
-	    this.style = style;
+		this.style = style;
 	}
 
 	/**
@@ -222,7 +227,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return リンクを表示するか
 	 */
 	public boolean isShowLink() {
-	    return showLink;
+		return showLink;
 	}
 
 	/**
@@ -230,7 +235,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param showLink リンクを表示するか
 	 */
 	public void setShowLink(boolean showLink) {
-	    this.showLink = showLink;
+		this.showLink = showLink;
 	}
 
 	/**
@@ -238,7 +243,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return 詳細編集非表示設定
 	 */
 	public boolean isHideDetail() {
-	    return hideDetail;
+		return hideDetail;
 	}
 
 	/**
@@ -246,7 +251,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param hideDetail 詳細編集非表示設定
 	 */
 	public void setHideDetail(boolean hideDetail) {
-	    this.hideDetail = hideDetail;
+		this.hideDetail = hideDetail;
 	}
 
 	/**
@@ -254,7 +259,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return 詳細表示非表示設定
 	 */
 	public boolean isHideView() {
-	    return hideView;
+		return hideView;
 	}
 
 	/**
@@ -262,7 +267,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param hideView 詳細表示非表示設定
 	 */
 	public void setHideView(boolean hideView) {
-	    this.hideView = hideView;
+		this.hideView = hideView;
 	}
 
 	/**
@@ -285,7 +290,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return 上部のコンテンツ
 	 */
 	public String getUpperContents() {
-	    return upperContents;
+		return upperContents;
 	}
 
 	/**
@@ -293,7 +298,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param upperContents 上部のコンテンツ
 	 */
 	public void setUpperContents(String upperContents) {
-	    this.upperContents = upperContents;
+		this.upperContents = upperContents;
 	}
 
 	/**
@@ -301,7 +306,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return 下部のコンテンツ
 	 */
 	public String getLowerContents() {
-	    return lowerContents;
+		return lowerContents;
 	}
 
 	/**
@@ -309,7 +314,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param lowerContents 下部のコンテンツ
 	 */
 	public void setLowerContents(String lowerContents) {
-	    this.lowerContents = lowerContents;
+		this.lowerContents = lowerContents;
 	}
 
 	/**
@@ -318,7 +323,7 @@ public class MetaReferenceSection extends MetaSection {
 	 */
 	public List<MetaNestProperty> getProperties() {
 		if (properties == null) properties = new ArrayList<>();
-	    return properties;
+		return properties;
 	}
 
 	/**
@@ -326,7 +331,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param properties 表示プロパティ
 	 */
 	public void setProperties(List<MetaNestProperty> properties) {
-	    this.properties = properties;
+		this.properties = properties;
 	}
 
 	/**
@@ -334,7 +339,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return 表示順プロパティ
 	 */
 	public String getOrderPropName() {
-	    return orderPropId;
+		return orderPropId;
 	}
 
 	/**
@@ -342,7 +347,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param orderPropName 表示順プロパティ
 	 */
 	public void setOrderPropName(String orderPropName) {
-	    this.orderPropId = orderPropName;
+		this.orderPropId = orderPropName;
 	}
 
 	/**
@@ -350,7 +355,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @return データのインデックス
 	 */
 	public int getIndex() {
-	    return index;
+		return index;
 	}
 
 	/**
@@ -358,7 +363,7 @@ public class MetaReferenceSection extends MetaSection {
 	 * @param index データのインデックス
 	 */
 	public void setIndex(int index) {
-	    this.index = index;
+		this.index = index;
 	}
 
 	/**
@@ -501,7 +506,7 @@ public class MetaReferenceSection extends MetaSection {
 
 	@Override
 	public SectionRuntime createRuntime(EntityViewRuntime entityView, FormViewRuntime formView) {
-		return new ReferenceSectionRuntime(this, entityView);
+		return new ReferenceSectionRuntime(this, entityView, formView);
 	}
 
 	/**
@@ -509,17 +514,55 @@ public class MetaReferenceSection extends MetaSection {
 	 * @author lis3wg
 	 *
 	 */
-	public class ReferenceSectionRuntime extends SectionRuntime {
+	public class ReferenceSectionRuntime extends SectionRuntime implements HasSectionPropertyRuntimeMap {
+		/**
+		 * Referenceセクションで保持しているプロパティランタイム情報マップ。
+		 * 本プロパティで取得できるプロパティは、ReferenceProperty で、ネストプロパティとして、参照先のプロパティを保持している。
+		 */
+		private Map<String, SectionPropertyRuntime> sectionPropertyRuntimeMap = new HashMap<>();
 
-		public ReferenceSectionRuntime(MetaReferenceSection metadata, EntityViewRuntime entityView) {
+		public ReferenceSectionRuntime(MetaReferenceSection metadata, EntityViewRuntime entityView, FormViewRuntime formView) {
 			super(metadata, entityView);
+
+			// TODO プロパティ名に変換する機能を利用するため、無名インスタンスを作成
+			HasEntityProperty propertyConverter = new HasEntityProperty() {
+			};
+			EntityContext ctx = EntityContext.getCurrentContext();
+			EntityHandler parentEntityHandler = ctx.getHandlerById(entityView.getMetaData().getDefinitionId());
+			ReferencePropertyHandler referencePropertyHandler = (ReferencePropertyHandler) parentEntityHandler
+					.getPropertyById(metadata.getPropertyId(), ctx);
+			EntityHandler referenceEntityHandler = referencePropertyHandler.getReferenceEntityHandler(ctx);
+
+			SectionPropertyRuntimeBuilder referencePropertyRuntimeBuilder = new SectionPropertyRuntimeBuilder(
+					referencePropertyHandler.getName());
+
 			if (properties != null && !properties.isEmpty()) {
+				Map<String, SectionPropertyRuntime> nestPropertyRuntimeMap = new HashMap<>();
 				for (MetaNestProperty meta : properties) {
 					if (meta.getAutocompletionSetting()  != null) {
 						entityView.addAutocompletionSetting(meta.getAutocompletionSetting().createRuntime(entityView));
 					}
+
+					// Referenceプロパティの参照先プロパティの情報を取得
+					String nestPropertyName = propertyConverter.convertName(meta.getPropertyId(), ctx, referenceEntityHandler);
+					SectionPropertyRuntimeBuilder nestPropertyRuntimeBuilder = new SectionPropertyRuntimeBuilder(nestPropertyName);
+
+					MetaPropertyEditor nestPropertyEditor = meta.getEditor();
+					if (null != nestPropertyEditor) {
+						// nestPropertyEditor が存在すれば、ランタイムを生成する
+						PropertyEditorRuntime runtime = (PropertyEditorRuntime) nestPropertyEditor.createRuntime(entityView, formView, null,
+								ctx, referenceEntityHandler);
+						nestPropertyRuntimeBuilder.editor(runtime);
+					}
+					// ネストプロパティを設定する
+					nestPropertyRuntimeMap.put(nestPropertyName, nestPropertyRuntimeBuilder.build());
 				}
+				// リファレンスプロパティにネストプロパティを設定
+				referencePropertyRuntimeBuilder.nest(nestPropertyRuntimeMap);
 			}
+			// プロパティを設定する
+			sectionPropertyRuntimeMap.put(referencePropertyHandler.getName(), referencePropertyRuntimeBuilder.build());
+
 			//上下コンテンツのコンパイル
 			if (StringUtil.isNotEmpty(metadata.upperContents) || StringUtil.isNotEmpty(metadata.lowerContents)) {
 				if (metadata.contentScriptKey == null) {
@@ -537,11 +580,17 @@ public class MetaReferenceSection extends MetaSection {
 					entityView.addTemplate(lowerKey, compile(metadata.lowerContents, lowerKey));
 				}
 			}
+
 		}
 
 		@Override
 		public MetaReferenceSection getMetaData() {
 			return (MetaReferenceSection) super.getMetaData();
+		}
+
+		@Override
+		public Map<String, SectionPropertyRuntime> getSectionPropertyRuntimeMap() {
+			return sectionPropertyRuntimeMap;
 		}
 
 		private GroovyTemplate compile(String script, String key) {
@@ -550,5 +599,4 @@ public class MetaReferenceSection extends MetaSection {
 					script, key, (GroovyScriptEngine) tenant.getScriptEngine());
 		}
 	}
-
 }

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaReferenceSection.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/MetaReferenceSection.java
@@ -40,7 +40,6 @@ import org.iplass.mtp.impl.script.template.GroovyTemplateCompiler;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.impl.view.generic.EntityViewRuntime;
 import org.iplass.mtp.impl.view.generic.FormViewRuntime;
-import org.iplass.mtp.impl.view.generic.HasEntityProperty;
 import org.iplass.mtp.impl.view.generic.editor.MetaNestProperty;
 import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor;
 import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor.PropertyEditorRuntime;
@@ -524,9 +523,6 @@ public class MetaReferenceSection extends MetaSection {
 		public ReferenceSectionRuntime(MetaReferenceSection metadata, EntityViewRuntime entityView, FormViewRuntime formView) {
 			super(metadata, entityView);
 
-			// TODO プロパティ名に変換する機能を利用するため、無名インスタンスを作成
-			HasEntityProperty propertyConverter = new HasEntityProperty() {
-			};
 			EntityContext ctx = EntityContext.getCurrentContext();
 			EntityHandler parentEntityHandler = ctx.getHandlerById(entityView.getMetaData().getDefinitionId());
 			ReferencePropertyHandler referencePropertyHandler = (ReferencePropertyHandler) parentEntityHandler
@@ -544,7 +540,7 @@ public class MetaReferenceSection extends MetaSection {
 					}
 
 					// Referenceプロパティの参照先プロパティの情報を取得
-					String nestPropertyName = propertyConverter.convertName(meta.getPropertyId(), ctx, referenceEntityHandler);
+					String nestPropertyName = meta.convertName(meta.getPropertyId(), ctx, referenceEntityHandler);
 					SectionPropertyRuntimeBuilder nestPropertyRuntimeBuilder = new SectionPropertyRuntimeBuilder(nestPropertyName);
 
 					MetaPropertyEditor nestPropertyEditor = meta.getEditor();

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionNestPropertyRuntime.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionNestPropertyRuntime.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.view.generic.element.section;
+
+import java.util.Map;
+
+/**
+ * セクションネストプロパティランタイム。
+ *
+ * <p>
+ * 本クラスでは、{@link org.iplass.mtp.impl.view.generic.element.section.SectionPropertyRuntimeImpl} で管理している情報に加え、以下の情報を管理する。
+ * <ul>
+ * <li>ネストプロパティランタイムマップ</li>
+ * </ul>
+ * </p>
+ *
+ * <p>package private</p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+class SectionNestPropertyRuntime extends SectionPropertyRuntimeImpl {
+	/** ネストプロパティランタイムマップ */
+	private Map<String, SectionPropertyRuntime> nest;
+
+	/**
+	 * コンストラクタ
+	 * @param propertyId プロパティID
+	 * @param nest ネストプロパティランタイムマップ
+	 */
+	public SectionNestPropertyRuntime(String propertyId, Map<String, SectionPropertyRuntime> nest) {
+		super(propertyId);
+		this.nest = nest;
+	}
+
+	/**
+	 * ネストプロパティランタイムマップを取得する
+	 * @return ネストプロパティランタイムマップ
+	 */
+	public Map<String, SectionPropertyRuntime> getNest() {
+		return nest;
+	}
+}

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionPropertyRuntime.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionPropertyRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
  *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
@@ -17,25 +17,31 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
+package org.iplass.mtp.impl.view.generic.element.section;
 
-package org.iplass.mtp.impl.view.generic;
+import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor.PropertyEditorRuntime;
 
-import java.util.List;
-
-import org.iplass.mtp.impl.view.generic.editor.MetaNestProperty;
-
-public interface HasMetaNestProperty {
+/**
+ * セクションプロパティランタイムインターフェース
+ *
+ * <p>
+ * 内部管理用のランタイム情報インターフェース
+ * </p>
+ *
+ * <p>package private</p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+interface SectionPropertyRuntime {
 	/**
-	 * オブジェクトIDを取得する。
-	 *
-	 * <p>
-	 * 本プロパティを所有する Entity のオブジェクト ID が設定されます。
-	 * </p>
-	 *
-	 * @return オブジェクトID
+	 * プロパティ名を取得する
+	 * @return プロパティ名
 	 */
-	String getObjectId();
+	String getPropertyName();
 
-	List<MetaNestProperty> getNestProperties();
-
+	/**
+	 * プロパティエディタを取得する
+	 * @return プロパティエディタ
+	 */
+	PropertyEditorRuntime getEditor();
 }

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionPropertyRuntimeBuilder.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionPropertyRuntimeBuilder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.view.generic.element.section;
+
+import java.util.Map;
+
+import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor.PropertyEditorRuntime;
+import org.iplass.mtp.impl.view.generic.element.ElementRuntime;
+
+/**
+ * セクションプロパティランタイムビルダー
+ *
+ * <p>package private</p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+class SectionPropertyRuntimeBuilder {
+	/** プロパティ名 */
+	private String propertyName;
+	/** プロパティエディタランタイム */
+	private PropertyEditorRuntime editor;
+	/** FormView要素ランタイム */
+	private ElementRuntime element;
+	/** ネストプロパティ*/
+	private Map<String, SectionPropertyRuntime> nest;
+
+	/**
+	 * コンストラクタ
+	 * @param propertyName プロパティ名
+	 */
+	public SectionPropertyRuntimeBuilder(String propertyName) {
+		this.propertyName = propertyName;
+	}
+
+	/**
+	 * プロパティエディタランタイムを設定する
+	 * @param editor プロパティエディタランタイム
+	 * @return 自インスタンス
+	 */
+	public SectionPropertyRuntimeBuilder editor(PropertyEditorRuntime editor) {
+		this.editor = editor;
+		return this;
+	}
+
+	/**
+	 * FormView要素ランタイムを設定する
+	 * @param element FormView要素ランタイム
+	 * @return 自インスタンス
+	 */
+	public SectionPropertyRuntimeBuilder element(ElementRuntime element) {
+		this.element = element;
+		return this;
+	}
+
+	/**
+	 * ネストプロパティランタイムを設定する
+	 * @param nest ネストプロパティランタイム
+	 * @return 自インスタンス
+	 */
+	public SectionPropertyRuntimeBuilder nest(Map<String, SectionPropertyRuntime> nest) {
+		this.nest = nest;
+		return this;
+	}
+
+	/**
+	 * インスタンスを生成する
+	 * @return InnerPropertyRuntime インスタンス
+	 */
+	public SectionPropertyRuntime build() {
+		// ネストプロパティランタイムの有無で生成インスタンスを分ける
+		SectionPropertyRuntimeImpl property = nest != null
+				? new SectionNestPropertyRuntime(propertyName, nest)
+				: new SectionPropertyRuntimeImpl(propertyName);
+		property.setEditor(editor);
+		property.setElement(element);
+		return property;
+	}
+}

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionPropertyRuntimeImpl.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/element/section/SectionPropertyRuntimeImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.view.generic.element.section;
+
+import org.iplass.mtp.impl.view.generic.editor.MetaPropertyEditor.PropertyEditorRuntime;
+import org.iplass.mtp.impl.view.generic.element.ElementRuntime;
+
+/**
+ * セクションプロパティランタイム
+ *
+ * <p>
+ * 本クラスでは以下の情報を管理する。
+ * <ul>
+ * <li>プロパティ名</li>
+ * <li>FormView要素ランタイム</li>
+ * <li>プロパティエディタランタイム</li>
+ * </p>
+ *
+ * <p>package private</p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+class SectionPropertyRuntimeImpl implements SectionPropertyRuntime {
+	/** プロパティ名*/
+	private String propertyName;
+	/** FormView要素ランタイム */
+	private ElementRuntime element;
+	/** プロパティエディタランタイム */
+	private PropertyEditorRuntime editor;
+
+	/**
+	 * コンストラクタ
+	 * @param propertyName プロパティ名
+	 */
+	public SectionPropertyRuntimeImpl(String propertyName) {
+		this.propertyName = propertyName;
+	}
+
+	@Override
+	public String getPropertyName() {
+		return propertyName;
+	}
+
+	/**
+	 * FormView要素ランタイムを取得する
+	 * @return FormView要素ランタイム
+	 */
+	public ElementRuntime getElement() {
+		return element;
+	}
+
+	/**
+	 * FormView要素ランタイムを設定する
+	 * @param element FormView要素ランタイム
+	 */
+	void setElement(ElementRuntime element) {
+		this.element = element;
+	}
+
+	@Override
+	public PropertyEditorRuntime getEditor() {
+		return editor;
+	}
+
+	/**
+	 * プロパティエディタランタイムを設定する
+	 * @param editor プロパティエディタランタイム
+	 */
+	void setEditor(PropertyEditorRuntime editor) {
+		this.editor = editor;
+	}
+}

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/binary/BinaryPropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/binary/BinaryPropertyEditor_Edit.jsp
@@ -29,6 +29,7 @@
 <%@ page import="org.iplass.mtp.auth.AuthContext" %>
 <%@ page import="org.iplass.mtp.entity.permission.EntityPropertyPermission" %>
 <%@ page import="org.iplass.mtp.entity.BinaryReference"%>
+<%@ page import="org.iplass.mtp.entity.definition.EntityDefinition" %>
 <%@ page import="org.iplass.mtp.entity.definition.PropertyDefinition" %>
 <%@ page import="org.iplass.mtp.util.StringUtil" %>
 <%@ page import="org.iplass.mtp.view.generic.editor.BinaryPropertyEditor" %>
@@ -137,7 +138,16 @@
 		if (pd.getMultiplicity() > 1) multiple = "multiple";
 
 		String viewName = (String)request.getAttribute(Constants.VIEW_NAME);
-		if (viewName == null) viewName = "";
+		if (viewName == null) {
+			viewName = "";
+		}
+		// NOTE ネストプロパティの場合、defName ではネスト先のエンティティ名が取得できてしまう。
+		//      entityDefinition キーで取得する値は表示しているビューのエンティティ定義なので、そこからエンティティ名を取得する
+		EntityDefinition entityDefinition = (EntityDefinition)request.getAttribute(Constants.ENTITY_DEFINITION);
+		String rootDefName = defName;
+		if (entityDefinition != null) {
+			rootDefName = entityDefinition.getName();
+		}
 
 		if (request.getAttribute(Constants.UPLOAD_LIB_LOADED) == null) {
 			request.setAttribute(Constants.UPLOAD_LIB_LOADED, true);
@@ -156,7 +166,7 @@
  data-showImageRotateButton="<%=editor.isShowImageRotateButton() %>"  data-openNewTab="<%=editor.isOpenNewTab() %>"
  data-multiplicity="<c:out value="<%=pd.getMultiplicity() %>" />" data-binWidth="<c:out value="<%=editor.getWidth() %>" />"
  data-binHeight="<c:out value="<%=editor.getHeight() %>" />" data-token="${m:fixToken()}" <c:out value="<%=multiple%>" /> 
- data-vname="<c:out value="<%=viewName %>"/>" data-dname="<c:out value="<%=defName %>"/>"
+ data-vname="<c:out value="<%=viewName %>"/>" data-dname="<c:out value="<%=rootDefName %>"/>"
  />
  <%
 		}

--- a/iplass-gem/src/main/resources/mtp-gem-messages.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages.properties
@@ -143,6 +143,7 @@ command.generic.detail.DetailCommandContext.inputDateRangeErr                 = 
 command.generic.detail.DetailCommandContext.inputNumericRangeErr              = Please fill in the value.
 command.generic.detail.DetailCommandContext.invalidDateRange                  = The relationship between periods is illegal.
 command.generic.detail.DetailCommandContext.invalidNumericRange               = The magnitude relationship between the numbers is illegal.
+command.generic.detail.DetailCommandContext.uncceptedFileType                 = The specified file format unaccepted. ({0})
 command.generic.detail.DetailViewCommand.failedCopy                           = Failed to copy.
 command.generic.detail.DetailViewCommand.failedDeepCopy                       = Failed to copy {0}.
 command.generic.detail.DetailViewCommand.illegalCopy                          = Copy target is invalid.

--- a/iplass-gem/src/main/resources/mtp-gem-messages_en.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_en.properties
@@ -143,6 +143,7 @@ command.generic.detail.DetailCommandContext.inputDateRangeErr                 = 
 command.generic.detail.DetailCommandContext.inputNumericRangeErr              = Please fill in the value.
 command.generic.detail.DetailCommandContext.invalidDateRange                  = The relationship between periods is illegal.
 command.generic.detail.DetailCommandContext.invalidNumericRange               = The magnitude relationship between the numbers is illegal.
+command.generic.detail.DetailCommandContext.uncceptedFileType                 = The specified file format unaccepted. ({0})
 command.generic.detail.DetailViewCommand.failedCopy                           = Failed to copy.
 command.generic.detail.DetailViewCommand.failedDeepCopy                       = Failed to copy {0}.
 command.generic.detail.DetailViewCommand.illegalCopy                          = Copy target is invalid.

--- a/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_ja.properties
@@ -143,6 +143,7 @@ command.generic.detail.DetailCommandContext.inputDateRangeErr                 = 
 command.generic.detail.DetailCommandContext.inputNumericRangeErr              = 値を入力してください。
 command.generic.detail.DetailCommandContext.invalidDateRange                  = 期間の前後関係が不正です。
 command.generic.detail.DetailCommandContext.invalidNumericRange               = 数値の大小関係が不正です。
+command.generic.detail.DetailCommandContext.uncceptedFileType                 = 指定されたファイル形式は受け付けられません。({0})
 command.generic.detail.DetailViewCommand.failedCopy                           = コピーに失敗しました。
 command.generic.detail.DetailViewCommand.failedDeepCopy                       = {0}のコピーに失敗しました。
 command.generic.detail.DetailViewCommand.illegalCopy                          = コピー対象が不正です。

--- a/iplass-gem/src/main/resources/mtp-gem-messages_th.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_th.properties
@@ -143,6 +143,7 @@ command.generic.detail.DetailCommandContext.inputDateRangeErr                 = 
 command.generic.detail.DetailCommandContext.inputNumericRangeErr              = กรุณากรอกค่า
 command.generic.detail.DetailCommandContext.invalidDateRange                  = ความสัมพันธ์ระหว่างระยะเวลาเป็นสิ่งผิดกฎหมาย
 command.generic.detail.DetailCommandContext.invalidNumericRange               = ขนาดความสัมพันธ์ระหว่างตัวเลขไม่ถูกต้อง
+command.generic.detail.DetailCommandContext.uncceptedFileType                 = รูปแบบไฟล์ที่ระบุไม่ได้รับการยอมรับ  ({0})
 command.generic.detail.DetailViewCommand.failedCopy                           = คัดลอกข้อมูลไม่สำเร็จ
 command.generic.detail.DetailViewCommand.failedDeepCopy                       = ไม่สามารถคัดลอก {0}
 command.generic.detail.DetailViewCommand.illegalCopy                          = ไม่สามารถคัดลอกข้อมูลนี้ได้

--- a/iplass-gem/src/main/resources/mtp-gem-messages_zh.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_zh.properties
@@ -143,6 +143,7 @@ command.generic.detail.DetailCommandContext.inputDateRangeErr                 = 
 command.generic.detail.DetailCommandContext.inputNumericRangeErr              = 请填写值。
 command.generic.detail.DetailCommandContext.invalidDateRange                  = 时期之间的关系是非法的。
 command.generic.detail.DetailCommandContext.invalidNumericRange               = 数字之间的大小关系是非法的。
+command.generic.detail.DetailCommandContext.uncceptedFileType                 = 不接受指定的文件格式。({0})
 command.generic.detail.DetailViewCommand.failedCopy                           = 复制失败了。
 command.generic.detail.DetailViewCommand.failedDeepCopy                       = 复制 {0} 失败了。
 command.generic.detail.DetailViewCommand.illegalCopy                          = 要复制的数据不正确。

--- a/iplass-gem/src/main/resources/mtp-gem-messages_zh_HK.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_zh_HK.properties
@@ -143,6 +143,7 @@ command.generic.detail.DetailCommandContext.inputDateRangeErr                 = 
 command.generic.detail.DetailCommandContext.inputNumericRangeErr              = 請填寫值。
 command.generic.detail.DetailCommandContext.invalidDateRange                  = 時期之間的關係是非法的。
 command.generic.detail.DetailCommandContext.invalidNumericRange               = 數字之間的大小關係是非法的。
+command.generic.detail.DetailCommandContext.uncceptedFileType                 = 不接受指定的文件格式。({0})
 command.generic.detail.DetailViewCommand.failedCopy                           = 複製失敗了。
 command.generic.detail.DetailViewCommand.failedDeepCopy                       = 複製 {0} 失敗了。
 command.generic.detail.DetailViewCommand.illegalCopy                          = 要復制的數據不正確。

--- a/iplass-gem/src/main/resources/mtp-gem-messages_zh_TW.properties
+++ b/iplass-gem/src/main/resources/mtp-gem-messages_zh_TW.properties
@@ -143,6 +143,7 @@ command.generic.detail.DetailCommandContext.inputDateRangeErr                 = 
 command.generic.detail.DetailCommandContext.inputNumericRangeErr              = 請填寫值。
 command.generic.detail.DetailCommandContext.invalidDateRange                  = 時期之間的關係是非法的。
 command.generic.detail.DetailCommandContext.invalidNumericRange               = 數字之間的大小關係是非法的。
+command.generic.detail.DetailCommandContext.uncceptedFileType                 = 不接受指定的文件格式。({0})
 command.generic.detail.DetailViewCommand.failedCopy                           = 複製失敗了。
 command.generic.detail.DetailViewCommand.failedDeepCopy                       = 複製 {0} 失敗了。
 command.generic.detail.DetailViewCommand.illegalCopy                          = 要復制的數據不正確。


### PR DESCRIPTION
- GemConfigService で保持するパターン情報をPatternインスタンスに変更
- 更新実行時にバイナリファイルタイプを検査
- プロパティエディタの検査パターンインスタンスを事前コンパイル
- FormViewRuntime 保持情報を整理
- プロパティのmultiple対応
- ネストプロパティ対応