### PR TITLE
テナント削除バッチ、大量データの考慮、ストレージスペースデータが一部削除できない（3.1）

### DIFF
--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/TenantToolService.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/TenantToolService.java
@@ -39,6 +39,7 @@ import org.iplass.mtp.impl.tools.tenant.create.TenantCreateProcess;
 import org.iplass.mtp.impl.tools.tenant.log.LogHandler;
 import org.iplass.mtp.impl.tools.tenant.rdb.TenantRdbManager;
 import org.iplass.mtp.impl.tools.tenant.rdb.TenantRdbManagerFactory;
+import org.iplass.mtp.impl.tools.tenant.rdb.TenantRdbManagerParameter;
 import org.iplass.mtp.impl.util.InternalDateUtil;
 import org.iplass.mtp.spi.Config;
 import org.iplass.mtp.spi.Service;
@@ -70,7 +71,6 @@ public class TenantToolService implements Service {
 
 	private TenantRdbManager rdbManager;
 
-	@SuppressWarnings("unchecked")
 	@Override
 	public void init(Config config) {
 		tenantContextService = config.getDependentService(TenantContextService.class);
@@ -80,9 +80,12 @@ public class TenantToolService implements Service {
 
 		RdbAdapter rdbAdapter = config.getDependentService(RdbAdapterService.class).getRdbAdapter();
 
-		createProcesses = (List<TenantCreateProcess>) config.getBeans("createProcesses");
+		createProcesses = config.getValues("createProcesses", TenantCreateProcess.class);
 
-		rdbManager = new TenantRdbManagerFactory().createManager(rdbAdapter);
+		// TenantRdbManager のパラメータを取得
+		TenantRdbManagerParameter parameter = config.getValue("tenantRdbManagerParameter", TenantRdbManagerParameter.class);
+		// TenantRdbManager インスタンス生成
+		rdbManager = new TenantRdbManagerFactory().createManager(rdbAdapter, parameter);
 	}
 
 	@Override

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/MySQLTenantRdbManager.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/MySQLTenantRdbManager.java
@@ -44,19 +44,19 @@ public class MySQLTenantRdbManager extends DefaultTenantRdbManager {
 
 	private static Logger logger = LoggerFactory.getLogger(MySQLTenantRdbManager.class);
 
-	private static final String MYSQL_EXIST_TABLE_SQL = "select count(*) from information_schema.tables where table_name = ?";
-	private static final String MYSQL_EXIST_TABLE_SQL_WITH_SCHEMA = "select count(*) from information_schema.tables where table_schema = ? and table_name = ?";
+	private static final String MYSQL_EXIST_TABLE_SQL = "select count(*) from information_schema.tables where lower(table_name) = lower(?)";
+	private static final String MYSQL_EXIST_TABLE_SQL_WITH_SCHEMA = "select count(*) from information_schema.tables where table_schema = ? and lower(table_name) = lower(?)";
 
-	private static final String MYSQL_MAX_PARTITION_SQL = "select partition_name from information_schema.partitions where table_name = ? order by length(partition_name) desc , partition_name desc";
-	private static final String MYSQL_MAX_PARTITION_SQL_WITH_SCHEMA = "select partition_name from information_schema.partitions where table_schema = ? and table_name = ? order by length(partition_name) desc , partition_name desc";
+	private static final String MYSQL_MAX_PARTITION_SQL = "select partition_name from information_schema.partitions where lower(table_name) = lower(?) order by length(partition_name) desc , partition_name desc";
+	private static final String MYSQL_MAX_PARTITION_SQL_WITH_SCHEMA = "select partition_name from information_schema.partitions where table_schema = ? and lower(table_name) = lower(?) order by length(partition_name) desc , partition_name desc";
 
-	private static final String MYSQL_EXIST_PARTITION_SQL = "select count(*) from information_schema.partitions where table_name = ? and partition_name = ?";
-	private static final String MYSQL_EXIST_PARTITION_SQL_WITH_SCHEMA = "select count(*) from information_schema.partitions where table_schema = ? and table_name = ? and partition_name = ?";
+	private static final String MYSQL_EXIST_PARTITION_SQL = "select count(*) from information_schema.partitions where lower(table_name) = lower(?) and lower(partition_name) = lower(?)";
+	private static final String MYSQL_EXIST_PARTITION_SQL_WITH_SCHEMA = "select count(*) from information_schema.partitions where table_schema = ? and lower(table_name) = lower(?) and lower(partition_name) = lower(?)";
 
 	private RdbAdapter adapter;
 
-	public MySQLTenantRdbManager(RdbAdapter adapter) {
-		super(adapter);
+	public MySQLTenantRdbManager(RdbAdapter adapter, TenantRdbManagerParameter parameter) {
+		super(adapter, parameter);
 		this.adapter = adapter;
 	}
 
@@ -427,6 +427,22 @@ public class MySQLTenantRdbManager extends DefaultTenantRdbManager {
 
 	private String getPartitionResourceMessage(String lang, String suffix, Object... args) {
 		return ToolsResourceBundleUtil.resourceString(lang, "tenant.partition." + suffix, args);
+	}
+
+	@Override
+	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+			int deleteRows) {
+		return new SqlExecuter<Integer>() {
+			@Override
+			public Integer logic() throws SQLException {
+				String sql = "delete from " + tableName + " where tenant_id = ? limit ?";
+				PreparedStatement ps = getPreparedStatement(sql);
+				ps.setInt(1, tenantId);
+				ps.setInt(2, deleteRows);
+
+				return ps.executeUpdate();
+			}
+		};
 	}
 
 }

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/MySQLTenantRdbManager.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/MySQLTenantRdbManager.java
@@ -430,7 +430,7 @@ public class MySQLTenantRdbManager extends DefaultTenantRdbManager {
 	}
 
 	@Override
-	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String deletionUnitColumns,
 			int deleteRows) {
 		return new SqlExecuter<Integer>() {
 			@Override

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/OracleTenantRdbManager.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/OracleTenantRdbManager.java
@@ -33,13 +33,13 @@ import org.iplass.mtp.impl.tools.tenant.log.LogHandler;
 
 public class OracleTenantRdbManager extends DefaultTenantRdbManager {
 
-	private static final String ORACLE_EXIST_TABLE_SQL = "select count(*) from user_tables where lower(table_name) = ?";
-	private static final String ORACLE_EXIST_SYNONYM_SQL = "select count(*) from user_synonyms where lower(synonym_name) = ?";
+	private static final String ORACLE_EXIST_TABLE_SQL = "select count(*) from user_tables where lower(table_name) = lower(?)";
+	private static final String ORACLE_EXIST_SYNONYM_SQL = "select count(*) from user_synonyms where lower(synonym_name) = lower(?)";
 
 	private RdbAdapter adapter;
 
-	public OracleTenantRdbManager(RdbAdapter adapter) {
-		super(adapter);
+	public OracleTenantRdbManager(RdbAdapter adapter, TenantRdbManagerParameter parameter) {
+		super(adapter, parameter);
 		this.adapter = adapter;
 	}
 
@@ -100,4 +100,19 @@ public class OracleTenantRdbManager extends DefaultTenantRdbManager {
 		};
 	}
 
+	@Override
+	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+			int deleteRows) {
+		return new SqlExecuter<Integer>() {
+			@Override
+			public Integer logic() throws SQLException {
+				String sql = "delete from " + tableName + " where tenant_id = ? and rownum <= ?";
+				PreparedStatement ps = getPreparedStatement(sql);
+				ps.setInt(1, tenantId);
+				ps.setInt(2, deleteRows);
+
+				return ps.executeUpdate();
+			}
+		};
+	}
 }

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/OracleTenantRdbManager.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/OracleTenantRdbManager.java
@@ -101,7 +101,7 @@ public class OracleTenantRdbManager extends DefaultTenantRdbManager {
 	}
 
 	@Override
-	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String deletionUnitColumns,
 			int deleteRows) {
 		return new SqlExecuter<Integer>() {
 			@Override

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/PostgreSQLTenantRdbManager.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/PostgreSQLTenantRdbManager.java
@@ -444,16 +444,16 @@ public class PostgreSQLTenantRdbManager extends DefaultTenantRdbManager {
 	}
 
 	@Override
-	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String deletionUnitColumns,
 			int deleteRows) {
 
-		if (StringUtil.isNotEmpty(uniqueColumn)) {
+		if (StringUtil.isNotEmpty(deletionUnitColumns)) {
 			// ユニークカラムの指定がある場合のSQLExecuter
 			return new SqlExecuter<Integer>() {
 				@Override
 				public Integer logic() throws SQLException {
-					String sql = "delete from " + tableName + " where (" + uniqueColumn + ") in (select " + uniqueColumn + " from "
-							+ tableName + " where tenant_id = ? limit ?)";
+					String sql = "delete from " + tableName + " where (" + deletionUnitColumns + ") in (select " + deletionUnitColumns
+							+ " from " + tableName + " where tenant_id = ? limit ?)";
 					PreparedStatement ps = getPreparedStatement(sql);
 					ps.setInt(1, tenantId);
 					ps.setInt(2, deleteRows);

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/SqlServerTenantRdbManager.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/SqlServerTenantRdbManager.java
@@ -283,7 +283,7 @@ public class SqlServerTenantRdbManager extends DefaultTenantRdbManager {
 	}
 
 	@Override
-	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String deletionUnitColumns,
 			int deleteRows) {
 		return new SqlExecuter<Integer>() {
 			@Override

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/SqlServerTenantRdbManager.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/SqlServerTenantRdbManager.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 
 import org.iplass.mtp.impl.rdb.SqlExecuter;
@@ -47,26 +48,32 @@ public class SqlServerTenantRdbManager extends DefaultTenantRdbManager {
 	private static final String SQL_TENANT_EXISTS = "select 1 where exists (select * from t_tenant where url = ?)";
 
 	private static final String SQL_GET_DB_NAME = "SELECT DB_NAME()";
-	private static final String SQL_GET_DB_FILE_PATH = "SELECT LEFT(PHYSICAL_NAME, LEN(PHYSICAL_NAME) - CHARINDEX('\\', REVERSE(PHYSICAL_NAME) + '\\'))"
-														+ "FROM (SELECT PHYSICAL_NAME FROM SYS.DATABASE_FILES WHERE NAME = '%s') AS PHYSICAL_NAME";
+	private static final String SQL_GET_DB_FILE_PATH_TEMPLATE = "SELECT LEFT(PHYSICAL_NAME, LEN(PHYSICAL_NAME) - CHARINDEX('\\', REVERSE(PHYSICAL_NAME) + '\\'))"
+			+ "FROM (SELECT PHYSICAL_NAME FROM SYS.DATABASE_FILES WHERE NAME = '%s') AS PHYSICAL_NAME";
 	private static final String SQL_ADD_FILEGROUP = "ALTER DATABASE %s ADD FILEGROUP %s";
 	private static final String SQL_ADD_FILEGROUP_FILE = "ALTER DATABASE %s ADD FILE ("
-														+ "NAME = %s, "
-														+ "FILENAME = '%s', "
-														+ "SIZE = 5MB, "
-														+ "FILEGROWTH = 1MB) TO FILEGROUP %s";
+			+ "NAME = %s, "
+			+ "FILENAME = '%s', "
+			+ "SIZE = 5MB, "
+			+ "FILEGROWTH = 1MB) TO FILEGROUP %s";
 	private static final String SQL_MOD_PARTITION_FUNCTION = "ALTER PARTITION FUNCTION " + PARTITION_FUNCTION_NAME + "() SPLIT RANGE (%d)";
 	private static final String SQL_MOD_PARTITION_SCHEME = "ALTER PARTITION SCHEME " + PARTITION_SCHEME_NAME + " NEXT USED %s";
 	private static final String SQL_EXIST_PARTITION_FUNCTION = "SELECT 'X' FROM SYS.PARTITION_FUNCTIONS WHERE NAME='"+ PARTITION_FUNCTION_NAME + "'";
 
-	private static final String SQLSERVER_EXIST_TABLE_SQL = "select count(*) from sys.tables where lower(name) = ?";
-	private static final String SQLSERVER_EXIST_SYNONYM_SQL = "select count(*) from sys.synonyms where lower(name) = ?";
+	private static final String SQLSERVER_EXIST_TABLE_SQL = "select count(*) from sys.tables where lower(name) = lower(?)";
+	private static final String SQLSERVER_EXIST_SYNONYM_SQL = "select count(*) from sys.synonyms where lower(name) = lower(?)";
 
 	private RdbAdapter adapter;
+	/** ファイルパスを取得するSQL。DBのOSによって区切り文字が変わる為、OSによって変更する。 */
+	private String sqlGetDbFilePath;
 
-	public SqlServerTenantRdbManager(RdbAdapter adapter) {
-		super(adapter);
+	public SqlServerTenantRdbManager(RdbAdapter adapter, TenantRdbManagerParameter parameter) {
+		super(adapter, parameter);
 		this.adapter = adapter;
+		// Windows であれば "\", それ以外は "/"
+		String pathSeparator = isDbServerOSWindows(adapter) ? "\\\\" : "/";
+		// \\ を pathSeparator に置換する
+		this.sqlGetDbFilePath = SQL_GET_DB_FILE_PATH_TEMPLATE.replaceAll("\\\\", pathSeparator);
 	}
 
 	@Override
@@ -172,7 +179,7 @@ public class SqlServerTenantRdbManager extends DefaultTenantRdbManager {
 		SqlExecuter<String> exec = new SqlExecuter<String>() {
 			@Override
 			public String logic() throws SQLException {
-				String sql = String.format(SQL_GET_DB_FILE_PATH, dbName);
+				String sql = String.format(sqlGetDbFilePath, dbName);
 				ResultSet rs = getPreparedStatement(sql).executeQuery();
 				rs.next();
 				return rs.getString(1);
@@ -273,6 +280,45 @@ public class SqlServerTenantRdbManager extends DefaultTenantRdbManager {
 
 	private String getCommonResourceMessage(String lang, String subKey, Object... args) {
 		return ToolsResourceBundleUtil.commonResourceString(lang, subKey, args);
+	}
+
+	@Override
+	protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+			int deleteRows) {
+		return new SqlExecuter<Integer>() {
+			@Override
+			public Integer logic() throws SQLException {
+				String sql = "delete top(?) from " + tableName + " where tenant_id = ?";
+				PreparedStatement ps = getPreparedStatement(sql);
+				ps.setInt(1, deleteRows);
+				ps.setInt(2, tenantId);
+
+				return ps.executeUpdate();
+			}
+		};
+	}
+
+	/**
+	 * DBサーバのOSがWindowsであるか確認する
+	 *
+	 * @param adapter RdbAdapter
+	 * @return DBサーバのOSがWindowsの場合 true
+	 */
+	protected boolean isDbServerOSWindows(RdbAdapter adapter) {
+		SqlExecuter<String> executer = new SqlExecuter<String>() {
+			@Override
+			public String logic() throws SQLException {
+				String sql = "select @@VERSION";
+				Statement ps = getStatement();
+
+				try (ResultSet rs = ps.executeQuery(sql)) {
+					return rs.next() ? rs.getString(1) : "";
+				}
+			}
+		};
+		String version = executer.execute(adapter, true);
+		// @@VERSION に WINDOWS という文字パターンが見つかれば、true を返却する
+		return version.toUpperCase().indexOf("WINDOWS") > 0;
 	}
 
 }

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbConstants.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbConstants.java
@@ -20,47 +20,64 @@
 
 package org.iplass.mtp.impl.tools.tenant.rdb;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public interface TenantRdbConstants {
 
+	/** テーブルリストとテーブルのユニークキー。ユニークキーが不明な場合は空文字を設定。（t_tenant, t_account を除く） */
+	@SuppressWarnings("serial")
+	public static final Map<String, String> TABLE_LIST_UNIQUE_COLS = Collections.unmodifiableMap(new HashMap<String, String>() {
+		{
+			put("counter", "tenant_id, cnt_name, inc_unit_key");
+			put("crawl_log", "tenant_id, obj_def_id, obj_def_ver");
+			// NOTE delete_log - PK なし
+			put("delete_log", "tenant_id, obj_def_id, obj_id, obj_ver");
+			put("lob_store", "tenant_id, lob_data_id");
+			// NOTE obj_blob - PK なし
+			put("obj_blob", "tenant_id, lob_id");
+			// NOTE obj_blob_rb - PK なし
+			put("obj_blob_rb", "tenant_id, rb_id");
+
+			// NOTE ver 3系では obj_data、obj_data_rb テーブルは存在しない
+			put("obj_data", "");
+			put("obj_data_rb", "");
+
+			put("obj_store", "tenant_id, obj_def_id, obj_id, obj_ver, pg_no");
+			put("obj_store_rb", "tenant_id, obj_def_id, rb_id");
+
+			// NOTE obj_ref - PK なし (ReferenceDeleteSql#deleteByOidAndVersion を参考に列指定）
+			put("obj_ref", "tenant_id, obj_def_id, ref_def_id, obj_id, obj_ver");
+			// NOTE obj_ref_rb - PK なし (obj_ref に rb_id を加えて列指定）
+			put("obj_ref_rb", "rb_id, tenant_id, obj_def_id, ref_def_id, obj_id, obj_ver");
+
+			// NOTE obj_index_* - PK なし (IndexDeleteSql#deleteByOidAndVersion を参考に列を指定)
+			put("obj_index_date", "tenant_id, obj_def_id, col_name, obj_id, obj_ver");
+			put("obj_index_dbl", "tenant_id, obj_def_id, col_name, obj_id, obj_ver");
+			put("obj_index_num", "tenant_id, obj_def_id, col_name, obj_id, obj_ver");
+			put("obj_index_str", "tenant_id, obj_def_id, col_name, obj_id, obj_ver");
+			put("obj_index_ts", "tenant_id, obj_def_id, col_name, obj_id, obj_ver");
+
+			// NOTE obj_index_* - PK なし (IndexDeleteSql#deleteByOidAndVersion を参考に列を指定)
+			put("obj_unique_date", "tenant_id, obj_def_id, col_name, obj_id");
+			put("obj_unique_dbl", "tenant_id, obj_def_id, col_name, obj_id");
+			put("obj_unique_num", "tenant_id, obj_def_id, col_name, obj_id");
+			put("obj_unique_str", "tenant_id, obj_def_id, col_name, obj_id");
+			put("obj_unique_ts", "tenant_id, obj_def_id, col_name, obj_id");
+
+			put("obj_meta", "tenant_id, obj_def_id, obj_def_ver");
+			put("schema_ctrl", "tenant_id, obj_def_id");
+			put("task_queue", "q_id, tenant_id, task_id");
+			put("task_queue_hi", "q_id, tenant_id, task_id");
+		}
+	});
+
 	/** テーブルリスト（t_tenant、t_accountを除く） */
-	public static final String[] TABLE_LIST = {
-		"counter",
-		"crawl_log",
-		"delete_log",
-		"lob_store",
-		"obj_blob",
-		"obj_blob_rb",
-
-		"obj_data",
-		"obj_data_rb",
-
-		"obj_store",
-		"obj_store_rb",
-
-		"obj_ref",
-		"obj_ref_rb",
-
-		"obj_index_date",
-		"obj_index_dbl",
-		"obj_index_num",
-		"obj_index_str",
-		"obj_index_ts",
-
-		"obj_unique_date",
-		"obj_unique_dbl",
-		"obj_unique_num",
-		"obj_unique_str",
-		"obj_unique_ts",
-
-		"obj_meta",
-		"schema_ctrl",
-		"task_queue",
-		"task_queue_hi"
-	};
+	public static final String[] TABLE_LIST = TABLE_LIST_UNIQUE_COLS.keySet().toArray(new String[TABLE_LIST_UNIQUE_COLS.size()]);
 
 	/**
 	 * <p>Partition除外テーブルリスト</p>

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbConstants.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbConstants.java
@@ -29,9 +29,13 @@ import java.util.stream.Stream;
 
 public interface TenantRdbConstants {
 
-	/** テーブルリストとテーブルのユニークキー。ユニークキーが不明な場合は空文字を設定。（t_tenant, t_account を除く） */
+	/**
+	 * テーブルリストとテーブルの削除単位カラム。削除単位カラムが不明な場合は空文字を設定。（t_tenant, t_account を除く）
+	 * 削除単位カラムは、削除時に件数指定が不可能な場合に使用する。実質利用はPostgreSQLのみ利用するカラムとなっている。
+	 */
 	@SuppressWarnings("serial")
-	public static final Map<String, String> TABLE_LIST_UNIQUE_COLS = Collections.unmodifiableMap(new HashMap<String, String>() {
+	public static final Map<String, String> TABLE_LIST_DELETION_UNIT_COLS = Collections
+			.unmodifiableMap(new HashMap<String, String>() {
 		{
 			put("counter", "tenant_id, cnt_name, inc_unit_key");
 			put("crawl_log", "tenant_id, obj_def_id, obj_def_ver");
@@ -77,7 +81,8 @@ public interface TenantRdbConstants {
 	});
 
 	/** テーブルリスト（t_tenant、t_accountを除く） */
-	public static final String[] TABLE_LIST = TABLE_LIST_UNIQUE_COLS.keySet().toArray(new String[TABLE_LIST_UNIQUE_COLS.size()]);
+	public static final String[] TABLE_LIST = TABLE_LIST_DELETION_UNIT_COLS.keySet()
+			.toArray(new String[TABLE_LIST_DELETION_UNIT_COLS.size()]);
 
 	/**
 	 * <p>Partition除外テーブルリスト</p>

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbManagerFactory.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbManagerFactory.java
@@ -20,8 +20,10 @@
 
 package org.iplass.mtp.impl.tools.tenant.rdb;
 
+import java.sql.SQLException;
 import java.util.List;
 
+import org.iplass.mtp.impl.rdb.SqlExecuter;
 import org.iplass.mtp.impl.rdb.adapter.RdbAdapter;
 import org.iplass.mtp.impl.rdb.mysql.MysqlRdbAdaptor;
 import org.iplass.mtp.impl.rdb.oracle.OracleRdbAdapter;
@@ -33,25 +35,25 @@ import org.iplass.mtp.impl.tools.tenant.log.LogHandler;
 
 public class TenantRdbManagerFactory {
 
-	public TenantRdbManager createManager(RdbAdapter adapter) {
+	public TenantRdbManager createManager(RdbAdapter adapter, TenantRdbManagerParameter parameter) {
 
 		if (adapter instanceof OracleRdbAdapter) {
-			return new OracleTenantRdbManager(adapter);
+			return new OracleTenantRdbManager(adapter, parameter);
 		} else if (adapter instanceof MysqlRdbAdaptor) {
-			return new MySQLTenantRdbManager(adapter);
+			return new MySQLTenantRdbManager(adapter, parameter);
 		} else if (adapter instanceof SqlServerRdbAdapter) {
-			return new SqlServerTenantRdbManager(adapter);
+			return new SqlServerTenantRdbManager(adapter, parameter);
 		} else if (adapter instanceof PostgreSQLRdbAdapter) {
-			return new PostgreSQLTenantRdbManager(adapter);
+			return new PostgreSQLTenantRdbManager(adapter, parameter);
 		} else {
-			return new EmptyTenantRdbManager(adapter);
+			return new EmptyTenantRdbManager(adapter, parameter);
 		}
 	}
 
 	private static class EmptyTenantRdbManager extends DefaultTenantRdbManager {
 
-		public EmptyTenantRdbManager(RdbAdapter adapter) {
-			super(adapter);
+		public EmptyTenantRdbManager(RdbAdapter adapter, TenantRdbManagerParameter parameter) {
+			super(adapter, parameter);
 		}
 
 		@Override
@@ -77,6 +79,17 @@ public class TenantRdbManagerFactory {
 		@Override
 		protected boolean isExistsTable(String tableName) {
 			return false;
+		}
+
+		@Override
+		protected SqlExecuter<Integer> getTenantRecordDeleteExecuter(int tenantId, String tableName, String uniqueColumn,
+				int deleteRows) {
+			return new SqlExecuter<Integer>() {
+				@Override
+				public Integer logic() throws SQLException {
+					return 0;
+				}
+			};
 		}
 
 	}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbManagerParameter.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbManagerParameter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.tools.tenant.rdb;
+
+/**
+ * TenartRdbManager パラメータ
+ *
+ * <p>
+ * 本クラスは、TenantToolService の初期化タイミングで TennatRdbManager のインスタンス生成時にパラメータ指定されます。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class TenantRdbManagerParameter {
+	/** 削除行数 */
+	private int deleteRows = 1_000_000;
+
+	/**
+	 * 削除行数を設定します
+	 * @param deleteRows 削除行数
+	 */
+	public void setDeleteRows(int deleteRows) {
+		this.deleteRows = deleteRows;
+	}
+
+	/**
+	 * 削除行数を取得します
+	 * @return 削除行数
+	 */
+	public int getDeleteRows() {
+		return deleteRows;
+	}
+}

--- a/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbManagerParameter.java
+++ b/iplass-tools/src/main/java/org/iplass/mtp/impl/tools/tenant/rdb/TenantRdbManagerParameter.java
@@ -30,7 +30,7 @@ package org.iplass.mtp.impl.tools.tenant.rdb;
  */
 public class TenantRdbManagerParameter {
 	/** 削除行数 */
-	private int deleteRows = 1_000_000;
+	private int deleteRows = 10_000;
 
 	/**
 	 * 削除行数を設定します

--- a/iplass-tools/src/main/resources/mtp-tools-messages.properties
+++ b/iplass-tools/src/main/resources/mtp-tools-messages.properties
@@ -115,6 +115,7 @@ tenant.create.createdTenantMetaMsg             = Created a Tenant meta data. : i
 tenant.create.createdTopViewMsg                = Created a TopView. : name = {0}
 tenant.create.existsURLMsg                     = Input URL is already exists. : url = {0}
 tenant.create.updatedTenantMetaMsg             = Updated a Tenant meta data. : id = {0}
+tenant.delete.deletingTableMsg                 = Deleting the {0} data. ({1})
 tenant.delete.deletedTableMsg                  = Deleted the {0} data. ({1})
 tenant.partition.createExistTenantPartitionMsg = Add the partition because there is no Partition to the tenant ({0}) .
 tenant.partition.createdPartitionMsg           = Created a Partition. : name = {0}

--- a/iplass-tools/src/main/resources/mtp-tools-messages_en.properties
+++ b/iplass-tools/src/main/resources/mtp-tools-messages_en.properties
@@ -20,7 +20,7 @@
 common.errorMsg = An unexpected error has occurred. : {0}
 
 entityport.alreadyExists         = [{0}] : You can not insert data because of the target is already registered. : key = {3} : mode = {4}
-entityport.bulkResultInfo        = [{0}] : ins({1}),upd({2}),del({3}),merge({4}). 
+entityport.bulkResultInfo        = [{0}] : ins({1}),upd({2}),del({3}),merge({4}).
 entityport.cantImportEntity      = [{0}] : Can not import data for [{0}].
 entityport.commitData            = [{0}] : Commited. line({1})
 entityport.csv.generateErr       = An error has occurred in the generation of the Entity.
@@ -34,7 +34,7 @@ entityport.importErrMessage      = [{0}] : An error occurred in the processing o
 entityport.importUserSkipMessage = [{0}] : The target user skipped for OID where was the same as a execute user. : line {1} : oid = {2} : account = {3}
 entityport.notExistsForDelete    = [{0}] : You can not delete data because of the target is not registered. : key = {3} : mode = {4}
 entityport.notExistsForUpdate    = [{0}] : You can not insert data because of the target is already registered. : key = {3} : mode = {4}
-entityport.resultInfo            = [{0}] : ins({1}),upd({2}),del({3}),err({4}). 
+entityport.resultInfo            = [{0}] : ins({1}),upd({2}),del({3}),err({4}).
 entityport.truncateData          = [{0}] : Registered data was deleted. ({1})
 entityport.updateErrMessage      = [{0}] : An error occurred in the process of updating the data. : line {1} : {2} : oid = {3}
 
@@ -60,9 +60,9 @@ metaport.statusCanNotRenameSharedData             = Share meta data can not chan
 metaport.statusCanNotRenameSharedDataDetail       = Share meta data can not change the Path.\nIf you take in, please to match the Path.\nChanged data ID={0}\nPrevious path={1}\nAfter path={2}
 metaport.statusCanNotRenameWithSharedDelete       = For registered data is shared data for the Path after the target data changes, you can not change the name.
 metaport.statusCanNotRenameWithSharedDeleteDetail = For registered data is shared data for the Path after the target data changes, you can not change the name.\nEither remove the registered share data that matches the Path after the change, please change the Path.\nChanged data ID={0}\nPrevious path={1}\nAfter path={2}\nPath matched share data ID={3}
-metaport.statusIncludeTenant                      = include tenant information. 
-metaport.statusIncludeTenantDetail                = Tenant information is included.  \nIf you import, you need to select the property.
-metaport.statusIncludeUnMatchTenant               = include tenant information (name unmatch). 
+metaport.statusIncludeTenant                      = include tenant information.
+metaport.statusIncludeTenantDetail                = Tenant information is included. \nIf you import, you need to select the property.
+metaport.statusIncludeUnMatchTenant               = include tenant information (name unmatch).
 metaport.statusIncludeUnMatchTenantDetail         = include tenant information (name unmatch). \nWhen importing you must select the property.
 metaport.statusInsertWithCombi                    = Add the metadata.
 metaport.statusInsertWithCombiDetail              = Add the metadata. Registered data that matches the Path is, will change the Path by another import data.\nIf you do not want to import the metadata that matches the Path of the registered data at the same time, you try to delete the registered data.\nAdd path={1}\nAdd data ID={0}\nAnother data ID={2}\nAnother data changed path={3}
@@ -115,6 +115,7 @@ tenant.create.createdTenantMetaMsg             = Created a Tenant meta data. : i
 tenant.create.createdTopViewMsg                = Created a TopView. : name = {0}
 tenant.create.existsURLMsg                     = Input URL is already exists. : url = {0}
 tenant.create.updatedTenantMetaMsg             = Updated a Tenant meta data. : id = {0}
+tenant.delete.deletingTableMsg                 = Deleting the {0} data. ({1})
 tenant.delete.deletedTableMsg                  = Deleted the {0} data. ({1})
 tenant.partition.createExistTenantPartitionMsg = Add the partition because there is no Partition to the tenant ({0}) .
 tenant.partition.createdPartitionMsg           = Created a Partition. : name = {0}

--- a/iplass-tools/src/main/resources/mtp-tools-messages_ja.properties
+++ b/iplass-tools/src/main/resources/mtp-tools-messages_ja.properties
@@ -115,6 +115,7 @@ tenant.create.createdTenantMetaMsg             = テナントメタデータを�
 tenant.create.createdTopViewMsg                = TopViewを作成しました。 : name = {0}
 tenant.create.existsURLMsg                     = すでに登録されているURLです。: url = {0}
 tenant.create.updatedTenantMetaMsg             = テナントメタデータを更新しました。 : id = {0}
+tenant.delete.deletingTableMsg                 = {0} を削除しています。: {1}件
 tenant.delete.deletedTableMsg                  = {0} を削除しました。: {1}件
 tenant.partition.createExistTenantPartitionMsg = テナント({0})に対するPartitionがないため追加します。
 tenant.partition.createdPartitionMsg           = Partitionを作成しました。 : name = {0}

--- a/iplass-tools/src/main/resources/mtp-tools-service-config.xml
+++ b/iplass-tools/src/main/resources/mtp-tools-service-config.xml
@@ -25,7 +25,14 @@
 		<property name="createProcesses" class="org.iplass.mtp.impl.tools.tenant.create.CreateAppAdminRoleProcess" />
 		<property name="createProcesses" class="org.iplass.mtp.impl.tools.tenant.create.CreateGemUserRoleProcess" />
 		<property name="createProcesses" class="org.iplass.mtp.impl.tools.tenant.create.CreateCompleteProcess" />
-
+		
+		<!-- TenartRdbManagerパラメータ -->
+		<property name="tenantRdbManagerParameter" class="org.iplass.mtp.impl.tools.tenant.rdb.TenantRdbManagerParameter">
+			<!-- テナント削除時のレコード削除件数。デフォルト値は 1,000,000 -->
+			<!--
+			<property name="deleteRows" value="1000000" />
+			-->
+		</property>
 	</service>
 
 	<service>

--- a/iplass-tools/src/main/resources/mtp-tools-service-config.xml
+++ b/iplass-tools/src/main/resources/mtp-tools-service-config.xml
@@ -28,9 +28,9 @@
 		
 		<!-- TenartRdbManagerパラメータ -->
 		<property name="tenantRdbManagerParameter" class="org.iplass.mtp.impl.tools.tenant.rdb.TenantRdbManagerParameter">
-			<!-- テナント削除時のレコード削除件数。デフォルト値は 1,000,000 -->
+			<!-- テナント削除時のレコード削除件数。デフォルト値は 10,000 -->
 			<!--
-			<property name="deleteRows" value="1000000" />
+			<property name="deleteRows" value="10000" />
 			-->
 		</property>
 	</service>


### PR DESCRIPTION
- テーブル存在チェックの大文字・小文字比較不具合修正
- TenantRdbManager にパラメータを追加
- SQLServerのパーティション作成クエリをDBサーバーのOSに依存しない形に修正
- 指定件数ごとにレコードを削除