### PR TITLE
CKEditorバージョンアップ

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/ckeditorResource.inc.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/layout/resource/ckeditorResource.inc.jsp
@@ -22,8 +22,8 @@
 <%@ page language="java" contentType="text/html; charset=utf-8" pageEncoding="utf-8" trimDirectiveWhitespaces="true" %>
 <%@ page import="org.iplass.mtp.web.template.TemplateUtil"%>
 
-<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/ckeditor/4.14.0/full/ckeditor.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
-<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/ckeditor/4.14.0/full/adapters/jquery.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
+<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/ckeditor/4.22.1/full/ckeditor.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
+<script type="text/javascript" src="${m:esc(staticContentPath)}/webjars/ckeditor/4.22.1/full/adapters/jquery.js?cv=<%=TemplateUtil.getAPIVersion()%>"></script>
 <script type="text/javascript">
 CKEDITOR.config.customConfig = "${m:esc(staticContentPath)}/scripts/gem/plugin/ckeditor/mtpconfig.js";
 </script>

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/ckeditor/mtpconfig.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/plugin/ckeditor/mtpconfig.js
@@ -35,7 +35,7 @@ CKEDITOR.editorConfig = function( config )
 	CKEDITOR.config.font_names='ＭＳ Ｐゴシック;ＭＳ Ｐ明朝;ＭＳ ゴシック;ＭＳ 明朝;Arial/Arial, Helvetica, sans-serif;Comic Sans MS/Comic Sans MS, cursive;Courier New/Courier New, Courier, monospace;Georgia/Georgia, serif;Lucida Sans Unicode/Lucida Sans Unicode, Lucida Grande, sans-serif;Tahoma/Tahoma, Geneva, sans-serif;Times New Roman/Times New Roman, Times, serif;Trebuchet MS/Trebuchet MS, Helvetica, sans-serif;Verdana/Verdana, Geneva, sans-serif';
 	CKEDITOR.config.enterMode = CKEDITOR.ENTER_BR;
 	CKEDITOR.config.toolbarCanCollapse = false;
-	CKEDITOR.config.removePlugins = 'maximize,resize';
+	CKEDITOR.config.removePlugins = 'maximize,resize,exportpdf';
 
 	CKEDITOR.dtd['a']['article'] = 1;
 	CKEDITOR.dtd['a']['aside'] = 1;

--- a/iplass-gem/src/main/resources/META-INF/resources/webjars/ckeditor/4.22.1/full/plugins/autogrow/plugin.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/webjars/ckeditor/4.22.1/full/plugins/autogrow/plugin.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
@@ -147,7 +147,9 @@
 			// to the one set by previous resizeEditor() call.
 			if ( newHeight != currentHeight && lastHeight != newHeight ) {
 				newHeight = editor.fire( 'autoGrow', { currentHeight: currentHeight, newHeight: newHeight } ).newHeight;
-				editor.resize( editor.container.getStyle( 'width' ), newHeight, true );
+
+				// Set width parameter as null, to update only the height of the editor. (#4891)
+				editor.resize( null, newHeight, true );
 				lastHeight = newHeight;
 			}
 

--- a/sharedlibs.gradle
+++ b/sharedlibs.gradle
@@ -102,7 +102,7 @@ ext {
 		//webjars(gem)
 		'org.webjars:jquery': '3.5.1',
 		'org.webjars:pdf-js': '3.1.81',
-		'org.webjars:ckeditor': '4.14.0',
+		'org.webjars:ckeditor': '4.22.1',
 		'org.webjars:jquery-blockui': '2.70-1',
 		'org.webjars:jQuery-Timepicker-Addon': '1.6.3',
 		'org.webjars:momentjs': '2.29.4',


### PR DESCRIPTION
- ライブラリバージョンアップ（4.14.0 -> 4.22.1）
- exportpdf プラグイン削除（Error code: exportpdf-no-token-url の抑制）