### PR TITLE
GEM、詳細検索でReferencePropertyEditorの「表示ラベルとして扱うプロパティ」を考慮する

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
@@ -105,8 +105,8 @@ public class GemConfigService implements Service {
 	/** 汎用検索のCSVダウンロードのフッター文言 */
 	private String csvDownloadFooter;
 
-	/** 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するか */
-	private boolean useDisplayLabelItemInDetailSearch;
+	/** 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するか */
+	private boolean useDisplayLabelItemInSearch;
 
 	/** プルダウンの「選択してください」を表示するか */
 	private boolean showPulldownPleaseSelectLabel;
@@ -206,7 +206,7 @@ public class GemConfigService implements Service {
 			csvDownloadFooter = "";
 		}
 
-		useDisplayLabelItemInDetailSearch = config.getValue("useDisplayLabelItemInDetailSearch", Boolean.class, false);
+		useDisplayLabelItemInSearch = config.getValue("useDisplayLabelItemInSearch", Boolean.class, false);
 
 		showPulldownPleaseSelectLabel = config.getValue("showPulldownPleaseSelectLabel", Boolean.class, true);
 
@@ -433,11 +433,11 @@ public class GemConfigService implements Service {
 	}
 
 	/**
-	 * 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するかを取得します。
-	 * @return 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するか
+	 * 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するかを取得します。
+	 * @return 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するか
 	 */
-	public boolean isUseDisplayLabelItemInDetailSearch() {
-		return useDisplayLabelItemInDetailSearch;
+	public boolean isUseDisplayLabelItemInSearch() {
+		return useDisplayLabelItemInSearch;
 	}
 
 	/**

--- a/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
@@ -105,6 +105,9 @@ public class GemConfigService implements Service {
 	/** 汎用検索のCSVダウンロードのフッター文言 */
 	private String csvDownloadFooter;
 
+	/** 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するか */
+	private boolean useDisplayLabelItemInDetailSearch;
+
 	/** プルダウンの「選択してください」を表示するか */
 	private boolean showPulldownPleaseSelectLabel;
 
@@ -202,6 +205,8 @@ public class GemConfigService implements Service {
 		if (csvDownloadFooter == null) {
 			csvDownloadFooter = "";
 		}
+
+		useDisplayLabelItemInDetailSearch = config.getValue("useDisplayLabelItemInDetailSearch", Boolean.class, false);
 
 		showPulldownPleaseSelectLabel = config.getValue("showPulldownPleaseSelectLabel", Boolean.class, true);
 
@@ -425,6 +430,14 @@ public class GemConfigService implements Service {
 	 */
 	public String getCsvDownloadFooter() {
 		return csvDownloadFooter;
+	}
+
+	/**
+	 * 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するかを取得します。
+	 * @return 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するか
+	 */
+	public boolean isUseDisplayLabelItemInDetailSearch() {
+		return useDisplayLabelItemInDetailSearch;
 	}
 
 	/**

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
@@ -174,9 +174,6 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 			} else {
 				Entity entity = (Entity) value;
 				if (entity.getName() != null && !entity.getName().isEmpty()) {
-					//conditions.add(new Like(getPropertyName() + ".name", "%" + StringUtil.escapeEqlForLike(entity.getName()) + "%"));
-					//conditions.add(new Like(getPropertyName() + "." + Entity.NAME, entity.getName(), Like.MatchPattern.PARTIAL));
-
 					// 検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
 					GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
 					String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
@@ -218,13 +215,14 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 			if (nestProperty == null || nestProperty instanceof ReferenceProperty) {
 				//nestPropertyがない(参照プロパティ自体)か参照のnestPropertyならnameで検索
 				Object conditionValue = convertDetailValue(detail);
-				propName = propName + "." + "name";
-
-				//検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
+				
 				GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
 				String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
 				if (service.isUseDisplayLabelItemInSearch() && displayLabelItem != null && !displayLabelItem.isBlank()) {
-					propName = detail.getPropertyName() + "." + displayLabelItem;
+					//表示ラベルとして扱うプロパティが設定されたら検索条件に利用する
+					propName = propName + "." + displayLabelItem;
+				} else {
+					propName = propName + "." + Entity.NAME;
 				}
 
 				if (Constants.EQUALS.equals(detail.getPredicate())) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
@@ -132,6 +132,21 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 						conditions.add(new In(getPropertyName() + "." + Entity.OID, oidList.toArray()));
 					}
 				}
+			} else if ((editor.getDisplayType() == ReferenceDisplayType.LINK && !editor.isUseSearchDialog())
+					 || (editor.getDisplayType() == ReferenceDisplayType.UNIQUE && !editor.isUseSearchDialog())){
+				// 検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
+				GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
+				if (service.isUseDisplayLabelItemInSearch()) {
+					String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
+
+					if(displayLabelItem != null && !displayLabelItem.isBlank()) {
+						// 表示ラベルの部分一致
+						Entity entity = (Entity) value;
+						if (entity.getName() != null && !entity.getName().isEmpty()) {
+							conditions.add(new Like(getPropertyName() + "." + displayLabelItem, entity.getName(), Like.MatchPattern.PARTIAL));
+						}
+					}
+				}
 			} else if (editor.getDisplayType() == ReferenceDisplayType.TREE) {
 				Entity[] list = (Entity[]) value;
 				if (list != null) {
@@ -210,14 +225,19 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 				Object conditionValue = convertDetailValue(detail);
 				propName = propName + "." + "name";
 
-				// 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用する
+				// 検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
 				GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
-				if (service.isUseDisplayLabelItemInDetailSearch()) {
+				if (service.isUseDisplayLabelItemInSearch()) {
 					String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
 					boolean isUseSearchDialog = getReferencePropertyEditor().isUseSearchDialog();
 
-					if(displayLabelItem != null && !displayLabelItem.isBlank() && isUseSearchDialog) {
-						propName = detail.getPropertyName() + "." + displayLabelItem;
+					if(displayLabelItem != null && !displayLabelItem.isBlank()) {
+						if(isUseSearchDialog) {
+							propName = detail.getPropertyName() + "." + displayLabelItem;
+						} else if ((getReferencePropertyEditor().getDisplayType() == ReferenceDisplayType.LINK && !isUseSearchDialog)
+								 || (getReferencePropertyEditor().getDisplayType() == ReferenceDisplayType.UNIQUE && !isUseSearchDialog)){
+							propName = detail.getPropertyName() + "." + displayLabelItem;
+						}
 					}
 				}
 

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
@@ -23,6 +23,7 @@ package org.iplass.gem.command.generic.search.condition;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.iplass.gem.GemConfigService;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.GemResourceBundleUtil;
 import org.iplass.gem.command.generic.search.SearchConditionDetail;
@@ -46,6 +47,7 @@ import org.iplass.mtp.entity.query.condition.predicate.Lesser;
 import org.iplass.mtp.entity.query.condition.predicate.LesserEqual;
 import org.iplass.mtp.entity.query.condition.predicate.Like;
 import org.iplass.mtp.entity.query.condition.predicate.NotEquals;
+import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.view.generic.editor.NestProperty;
 import org.iplass.mtp.view.generic.editor.PropertyEditor;
@@ -207,6 +209,16 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 				//nestPropertyがない(参照プロパティ自体)か参照のnestPropertyならnameで検索
 				Object conditionValue = convertDetailValue(detail);
 				propName = propName + "." + "name";
+
+				// 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用する
+				GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
+				if (service.isUseDisplayLabelItemInDetailSearch()) {
+					String strDisplayLabelItem = ((ReferencePropertyEditor)getReferencePropertyEditor()).getDisplayLabelItem();
+					boolean blIsUseSearchDialog = ((ReferencePropertyEditor)getReferencePropertyEditor()).isUseSearchDialog();
+					if(!strDisplayLabelItem.isBlank() && blIsUseSearchDialog) {
+						propName = detail.getPropertyName() + "." + strDisplayLabelItem;
+					}
+				}
 
 				if (Constants.EQUALS.equals(detail.getPredicate())) {
 					conditions.add(new Equals(propName, conditionValue));

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
@@ -213,10 +213,11 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 				// 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用する
 				GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
 				if (service.isUseDisplayLabelItemInDetailSearch()) {
-					String strDisplayLabelItem = ((ReferencePropertyEditor)getReferencePropertyEditor()).getDisplayLabelItem();
-					boolean blIsUseSearchDialog = ((ReferencePropertyEditor)getReferencePropertyEditor()).isUseSearchDialog();
-					if(!strDisplayLabelItem.isBlank() && blIsUseSearchDialog) {
-						propName = detail.getPropertyName() + "." + strDisplayLabelItem;
+					String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
+					boolean isUseSearchDialog = getReferencePropertyEditor().isUseSearchDialog();
+
+					if(displayLabelItem != null && !displayLabelItem.isBlank() && isUseSearchDialog) {
+						propName = detail.getPropertyName() + "." + displayLabelItem;
 					}
 				}
 

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/ReferencePropertySearchCondition.java
@@ -132,21 +132,6 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 						conditions.add(new In(getPropertyName() + "." + Entity.OID, oidList.toArray()));
 					}
 				}
-			} else if ((editor.getDisplayType() == ReferenceDisplayType.LINK && !editor.isUseSearchDialog())
-					 || (editor.getDisplayType() == ReferenceDisplayType.UNIQUE && !editor.isUseSearchDialog())){
-				// 検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
-				GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
-				if (service.isUseDisplayLabelItemInSearch()) {
-					String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
-
-					if(displayLabelItem != null && !displayLabelItem.isBlank()) {
-						// 表示ラベルの部分一致
-						Entity entity = (Entity) value;
-						if (entity.getName() != null && !entity.getName().isEmpty()) {
-							conditions.add(new Like(getPropertyName() + "." + displayLabelItem, entity.getName(), Like.MatchPattern.PARTIAL));
-						}
-					}
-				}
 			} else if (editor.getDisplayType() == ReferenceDisplayType.TREE) {
 				Entity[] list = (Entity[]) value;
 				if (list != null) {
@@ -187,11 +172,21 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 					}
 				}
 			} else {
-				//名前の部分一致
 				Entity entity = (Entity) value;
 				if (entity.getName() != null && !entity.getName().isEmpty()) {
 					//conditions.add(new Like(getPropertyName() + ".name", "%" + StringUtil.escapeEqlForLike(entity.getName()) + "%"));
-					conditions.add(new Like(getPropertyName() + "." + Entity.NAME, entity.getName(), Like.MatchPattern.PARTIAL));
+					//conditions.add(new Like(getPropertyName() + "." + Entity.NAME, entity.getName(), Like.MatchPattern.PARTIAL));
+
+					// 検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
+					GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
+					String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
+					if (service.isUseDisplayLabelItemInSearch() && displayLabelItem != null && !displayLabelItem.isBlank()) {
+						//表示ラベルの部分一致
+						conditions.add(new Like(getPropertyName() + "." + displayLabelItem, entity.getName(), Like.MatchPattern.PARTIAL));
+					} else {
+						//名前の部分一致
+						conditions.add(new Like(getPropertyName() + "." + Entity.NAME, entity.getName(), Like.MatchPattern.PARTIAL));
+					}
 				}
 			}
 		}
@@ -225,20 +220,11 @@ public class ReferencePropertySearchCondition extends PropertySearchCondition {
 				Object conditionValue = convertDetailValue(detail);
 				propName = propName + "." + "name";
 
-				// 検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
+				//検索処理で表示ラベルとして扱うプロパティを検索条件に利用する
 				GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
-				if (service.isUseDisplayLabelItemInSearch()) {
-					String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
-					boolean isUseSearchDialog = getReferencePropertyEditor().isUseSearchDialog();
-
-					if(displayLabelItem != null && !displayLabelItem.isBlank()) {
-						if(isUseSearchDialog) {
-							propName = detail.getPropertyName() + "." + displayLabelItem;
-						} else if ((getReferencePropertyEditor().getDisplayType() == ReferenceDisplayType.LINK && !isUseSearchDialog)
-								 || (getReferencePropertyEditor().getDisplayType() == ReferenceDisplayType.UNIQUE && !isUseSearchDialog)){
-							propName = detail.getPropertyName() + "." + displayLabelItem;
-						}
-					}
+				String displayLabelItem = getReferencePropertyEditor().getDisplayLabelItem();
+				if (service.isUseDisplayLabelItemInSearch() && displayLabelItem != null && !displayLabelItem.isBlank()) {
+					propName = detail.getPropertyName() + "." + displayLabelItem;
 				}
 
 				if (Constants.EQUALS.equals(detail.getPredicate())) {

--- a/iplass-gem/src/main/resources/gem-service-config.xml
+++ b/iplass-gem/src/main/resources/gem-service-config.xml
@@ -131,8 +131,8 @@
 		<!-- 汎用検索のCSVダウンロードのフッター文言 -->
 		<property name="csvDownloadFooter" value=""/>
 
-		<!-- 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するか -->
-		<property name="useDisplayLabelItemInDetailSearch" value="false"/>
+		<!-- 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するか -->
+		<property name="useDisplayLabelItemInSearch" value="false"/>
 
 		<!-- CSVアップロード非同期設定 -->
 		<!-- true(非同期)を設定する場合は、 RdbQueueServiceのuseQueueプロパティをtrueに設定してください。 -->

--- a/iplass-gem/src/main/resources/gem-service-config.xml
+++ b/iplass-gem/src/main/resources/gem-service-config.xml
@@ -131,6 +131,9 @@
 		<!-- 汎用検索のCSVダウンロードのフッター文言 -->
 		<property name="csvDownloadFooter" value=""/>
 
+		<!-- 詳細検索で表示ラベルとして扱うプロパティを検索条件に利用するか -->
+		<property name="useDisplayLabelItemInDetailSearch" value="false"/>
+
 		<!-- CSVアップロード非同期設定 -->
 		<!-- true(非同期)を設定する場合は、 RdbQueueServiceのuseQueueプロパティをtrueに設定してください。 -->
 		<property name="csvUploadAsync" value="false"/>


### PR DESCRIPTION
GEM、詳細検索でReferencePropertyEditorの「表示ラベルとして扱うプロパティ」を考慮する。
ReferencePropertyEditorで「表示ラベルとして扱うプロパティ」として設定された項目を通常検索のテキスト入力による条件指定時、または詳細検索の条件項目として設定します。

後方互換性を保つため、GemConfigServiceにフラグを追加し、挙動を変更できるようにする（デフォルトでは、現状の挙動のまま）。