### PR TITLE
GEM、RangePropertyEditorの検索条件で、「<=」「<」、「>=」「>」を指定可能にする

### DIFF
--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_en.js
@@ -1838,6 +1838,8 @@ LocaleInfo.generic_editor_DateRangePropertyEditor_editorDisplaNameKey = "Propert
 LocaleInfo.generic_editor_DateRangePropertyEditor_editorDescriptionKey = "Set the property editor tailored to the type of the property.";
 LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullFromDisplayNameKey = "Allow no input of From";
 LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullFromDescriptionKey = "Edit screen: Allows no input in the From input field. <br> Search condition: Adds data for which From is not entered to the search target.";
+LocaleInfo.generic_editor_DateRangePropertyEditor_fromConditionAsLesserEqualDisplayNameKey = "Conditions of the From property including values";
+LocaleInfo.generic_editor_DateRangePropertyEditor_fromConditionAsLesserEqualDescriptionKey = "Sets the search condition for the From property to include the value (<=)";
 LocaleInfo.generic_editor_DateRangePropertyEditor_toPropertyNameDisplaNameKey = "To property name";
 LocaleInfo.generic_editor_DateRangePropertyEditor_toPropertyNameDescriptionKey = "Specify other properties to display in combination with this property. <br>Please match the property type you specify with this property.";
 LocaleInfo.generic_editor_DateRangePropertyEditor_toEditorDisplaNameKey = "To property editor";
@@ -1846,7 +1848,9 @@ LocaleInfo.generic_editor_DateRangePropertyEditor_toPropertyDisplayNameDisplaNam
 LocaleInfo.generic_editor_DateRangePropertyEditor_toPropertyDisplayNameDescriptionKey = "Set the label of the To property to be displayed in the detailed search.";
 LocaleInfo.generic_editor_DateRangePropertyEditor_localizedToPropertyDisplayNameListDisplaNameKey = "Multilingual setting of To property display name in detailed search";
 LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullToDisplayNameKey = "Allow no input of To";
-LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullToDescriptionKey = "Edit screen: Allows no input in the From input field. <br> Search condition: Adds data for which From is not entered to the search target.";
+LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullToDescriptionKey = "Edit screen: Allows no input in the To input field. <br> Search condition: Adds data for which To is not entered to the search target.";
+LocaleInfo.generic_editor_DateRangePropertyEditor_toConditionAsGreaterEqualDisplayNameKey = "Conditions of the To property including values";
+LocaleInfo.generic_editor_DateRangePropertyEditor_toConditionAsGreaterEqualDescriptionKey = "Sets the search condition for the To property to include the value (>=)";
 LocaleInfo.generic_editor_DateRangePropertyEditor_equivalentInputDisplayNameKey = "Equivalence allowed";
 LocaleInfo.generic_editor_DateRangePropertyEditor_equivalentInputDescriptionKey = "Edit screen: Allows the same value to be set for From and To. <br> Search condition: Adds data with the same value of From and To to the search target.";
 LocaleInfo.generic_editor_DateRangePropertyEditor_errorMessageNameDisplaNameKey = "Error message";
@@ -1936,6 +1940,8 @@ LocaleInfo.generic_editor_NumericRangePropertyEditor_editorDisplaNameKey = "Prop
 LocaleInfo.generic_editor_NumericRangePropertyEditor_editorDescriptionKey = "Set the property editor tailored to the type of the property.";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullFromDisplayNameKey = "Allow no input of From";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullFromDescriptionKey = "Edit screen: Allows no input in the From input field. <br> Search condition: Adds data for which From is not entered to the search target.";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_fromConditionAsLesserEqualDisplayNameKey = "Conditions of the From property including values";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_fromConditionAsLesserEqualDescriptionKey = "Sets the search condition for the From property to include the value (<=)";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toPropertyNameDisplaNameKey = "To property name";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toPropertyNameDescriptionKey = "Specify other properties to display in combination with this property. <br>Please match the property type you specify with this property.";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toPropertyDisplayNameDisplaNameKey = "To property display name in detailed search";
@@ -1944,7 +1950,9 @@ LocaleInfo.generic_editor_NumericRangePropertyEditor_localizedToPropertyDisplayN
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toEditorDisplaNameKey = "To property editor";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toEditorDescriptionKey = "Set the property editor tailored to the type of the property.<br>If unspecified, the property editor setting will be effective.";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullToDisplayNameKey = "Allow no input of To";
-LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullToDescriptionKey = "Edit screen: Allows no input in the From input field. <br> Search condition: Adds data for which From is not entered to the search target.";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullToDescriptionKey = "Edit screen: Allows no input in the To input field. <br> Search condition: Adds data for which To is not entered to the search target.";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_toConditionAsGreaterEqualDisplayNameKey = "Conditions of the To property including values";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_toConditionAsGreaterEqualDescriptionKey = "Sets the search condition for the To property to include the value (>=)";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_equivalentInputDisplayNameKey = "Equivalence allowed";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_equivalentInputDescriptionKey = "Edit screen: Allows the same value to be set for From and To. <br> Search condition: Adds data with the same value of From and To to the search target.";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_errorMessageNameDisplaNameKey = "Error message";

--- a/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
+++ b/iplass-admin/src/main/resources/org/iplass/adminconsole/public/locale/locale_ja.js
@@ -1838,6 +1838,8 @@ LocaleInfo.generic_editor_DateRangePropertyEditor_editorDisplaNameKey = "プロ�
 LocaleInfo.generic_editor_DateRangePropertyEditor_editorDescriptionKey = "プロパティの型にあわせたプロパティエディタを選択してください。";
 LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullFromDisplayNameKey = "Fromの未入力を許容";
 LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullFromDescriptionKey = "編集画面：Fromの入力欄の未入力を許容します。<br>検索条件：Fromが未入力のデータを検索対象に追加します。";
+LocaleInfo.generic_editor_DateRangePropertyEditor_fromConditionAsLesserEqualDisplayNameKey = "Fromプロパティに対して値を含めて検索する";
+LocaleInfo.generic_editor_DateRangePropertyEditor_fromConditionAsLesserEqualDescriptionKey = "Fromプロパティに対して値を含めて検索する（<=）かを設定します。";
 LocaleInfo.generic_editor_DateRangePropertyEditor_toPropertyNameDisplaNameKey = "Toプロパティ名";
 LocaleInfo.generic_editor_DateRangePropertyEditor_toPropertyNameDescriptionKey = "このプロパティと組み合わせて表示する他のプロパティを指定します。<br>指定するプロパティの型はこのプロパティに合わせて下さい。";
 LocaleInfo.generic_editor_DateRangePropertyEditor_toEditorDisplaNameKey = "Toプロパティエディタ";
@@ -1847,6 +1849,8 @@ LocaleInfo.generic_editor_DateRangePropertyEditor_toPropertyDisplayNameDescripti
 LocaleInfo.generic_editor_DateRangePropertyEditor_localizedToPropertyDisplayNameListDisplaNameKey = "詳細検索でのToプロパティ表示名の多言語設定";
 LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullToDisplayNameKey = "Toの未入力を許容";
 LocaleInfo.generic_editor_DateRangePropertyEditor_inputNullToDescriptionKey = "編集画面：Toの入力欄の未入力を許容します。<br>検索条件：Toが未入力のデータを検索対象に追加します。";
+LocaleInfo.generic_editor_DateRangePropertyEditor_toConditionAsGreaterEqualDisplayNameKey = "Toプロパティに対して値を含めて検索する";
+LocaleInfo.generic_editor_DateRangePropertyEditor_toConditionAsGreaterEqualDescriptionKey = "Toプロパティに対して値を含めて検索する（>=）かを設定します。";
 LocaleInfo.generic_editor_DateRangePropertyEditor_equivalentInputDisplayNameKey = "同値を許容";
 LocaleInfo.generic_editor_DateRangePropertyEditor_equivalentInputDescriptionKey = "編集画面：FromとToに同値が設定されるのを許容します。<br>検索条件：FromとToが同値のデータを検索対象に追加します。";
 LocaleInfo.generic_editor_DateRangePropertyEditor_errorMessageNameDisplaNameKey = "エラーメッセージ";
@@ -1936,6 +1940,8 @@ LocaleInfo.generic_editor_NumericRangePropertyEditor_editorDisplaNameKey = "プ�
 LocaleInfo.generic_editor_NumericRangePropertyEditor_editorDescriptionKey = "プロパティの型にあわせたプロパティエディタを選択してください。";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullFromDisplayNameKey = "Fromの未入力を許容";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullFromDescriptionKey = "編集画面：Fromの入力欄の未入力を許容します。<br>検索条件：Fromが未入力のデータを検索対象に追加します。";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_fromConditionAsLesserEqualDisplayNameKey = "Fromプロパティに対して値を含めて検索する";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_fromConditionAsLesserEqualDescriptionKey = "Fromプロパティに対して値を含めて検索する（<=）かを設定します。";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toPropertyNameDisplaNameKey = "Toプロパティ名";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toPropertyNameDescriptionKey = "このプロパティと組み合わせて表示する他のプロパティを指定します。<br>指定するプロパティの型はこのプロパティに合わせて下さい。";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toPropertyDisplayNameDisplaNameKey = "詳細検索でのToプロパティ表示名";
@@ -1945,6 +1951,8 @@ LocaleInfo.generic_editor_NumericRangePropertyEditor_toEditorDisplaNameKey = "To
 LocaleInfo.generic_editor_NumericRangePropertyEditor_toEditorDescriptionKey = "プロパティの型にあわせたプロパティエディタを選択してください。<br>未指定の場合、プロパティエディタの設定が有効になります。";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullToDisplayNameKey = "Toの未入力を許容";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_inputNullToDescriptionKey = "編集画面：Toの入力欄の未入力を許容します。<br>検索条件：Toが未入力のデータを検索対象に追加します。";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_toConditionAsGreaterEqualDisplayNameKey = "Toプロパティに対して値を含めて検索する";
+LocaleInfo.generic_editor_NumericRangePropertyEditor_toConditionAsGreaterEqualDescriptionKey = "Toプロパティに対して値を含めて検索する（>=）かを設定します。";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_equivalentInputDisplayNameKey = "同値を許容";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_equivalentInputDescriptionKey = "編集画面：FromとToに同値が設定されるのを許容します。<br>検索条件：FromとToが同値のデータを検索対象に追加します。";
 LocaleInfo.generic_editor_NumericRangePropertyEditor_errorMessageNameDisplaNameKey = "エラーメッセージ";

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/DateRangePropertySearchCondition.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/condition/DateRangePropertySearchCondition.java
@@ -27,6 +27,11 @@ import org.iplass.mtp.entity.definition.PropertyDefinition;
 import org.iplass.mtp.entity.query.condition.Condition;
 import org.iplass.mtp.entity.query.condition.expr.And;
 import org.iplass.mtp.entity.query.condition.expr.Or;
+import org.iplass.mtp.entity.query.condition.predicate.Greater;
+import org.iplass.mtp.entity.query.condition.predicate.GreaterEqual;
+import org.iplass.mtp.entity.query.condition.predicate.IsNull;
+import org.iplass.mtp.entity.query.condition.predicate.Lesser;
+import org.iplass.mtp.entity.query.condition.predicate.LesserEqual;
 import org.iplass.mtp.view.generic.editor.DateRangePropertyEditor;
 import org.iplass.mtp.view.generic.editor.PropertyEditor;
 
@@ -67,39 +72,71 @@ public class DateRangePropertySearchCondition extends PropertySearchCondition {
 	@Override
 	public List<Condition> convertNormalCondition() {
 		List<Condition> conditions = new ArrayList<>();
-		String parentName = "";
 		Object[] obl = (Object[]) getValue();
-		//From-To検索
-		Object val = null;
+
 		boolean inputNullFrom = getEditor().isInputNullFrom();
 		boolean inputNullTo = getEditor().isInputNullTo();
 		boolean equivalentInput = getEditor().isEquivalentInput();
-		Or or = new Or();
 
 		if (obl.length > 0 && obl[0] != null) {
-			val = obl[0];
-		}
-		if (val != null) {
+			Object val = obl[0];
+
+			String parentName = "";
 			if (getParent() != null && getEditor().getToPropertyName().indexOf(".") == -1) {
 				parentName =  getParent()  + ".";
 			}
-			or.addExpression(new And().lte(getPropertyName(), val).gt(parentName + getEditor().getToPropertyName(), val));
+			String fromPropertyName = getPropertyName();
+			String toPropertyName = parentName + getEditor().getToPropertyName();
+
+			Or or = new Or();
+			or.addExpression(new And(fromCondition(fromPropertyName, val), toCondition(toPropertyName, val)));
 
 			if (inputNullFrom) {
-				or.addExpression(new And().isNull(getPropertyName()).gt(parentName + getEditor().getToPropertyName(), val));
+				or.addExpression(new And(new IsNull(fromPropertyName), toCondition(toPropertyName, val)));
 			}
 
 			if (inputNullTo) {
-				or.addExpression(new And().lte(getPropertyName(), val).isNull(parentName + getEditor().getToPropertyName()));
+				or.addExpression(new And(fromCondition(fromPropertyName, val), new IsNull(toPropertyName)));
 			}
 
 			if (equivalentInput) {
-				or.addExpression(new And().eq(getPropertyName(), val).eq(parentName + getEditor().getToPropertyName(), val));
+				or.addExpression(new And().eq(fromPropertyName, val).eq(toPropertyName, val));
 			}
+
+			conditions.add(or);
 		}
-		conditions.add(or);
 
 		return conditions;
+	}
+
+	/**
+	 * Fromの比較条件を返します。
+	 *
+	 * @param propertyName プロパティ名
+	 * @param value 値
+	 * @return Fromの比較条件
+	 */
+	private Condition fromCondition(String propertyName, Object value) {
+		if (getEditor().isFromConditionAsLesserEqual()) {
+			return new LesserEqual(propertyName, value);
+		} else {
+			return new Lesser(propertyName, value);
+		}
+	}
+
+	/**
+	 * Toの比較条件を返します。
+	 *
+	 * @param propertyName プロパティ名
+	 * @param value 値
+	 * @return Toの比較条件
+	 */
+	private Condition toCondition(String propertyName, Object value) {
+		if (getEditor().isToConditionAsGreaterEqual()) {
+			return new GreaterEqual(propertyName, value);
+		} else {
+			return new Greater(propertyName, value);
+		}
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaDateRangePropertyEditor.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaDateRangePropertyEditor.java
@@ -56,6 +56,9 @@ public class MetaDateRangePropertyEditor extends MetaCustomPropertyEditor implem
 	/** FromのNull許容フラグ */
 	private boolean inputNullFrom;
 
+	/** Fromプロパティに対して値を含めて検索する*/
+	private boolean fromConditionAsLesserEqual = true;
+
 	/** Toプロパティエディタ */
 	private MetaPropertyEditor toEditor;
 
@@ -70,6 +73,9 @@ public class MetaDateRangePropertyEditor extends MetaCustomPropertyEditor implem
 
 	/** ToのNull許容フラグ */
 	private boolean inputNullTo;
+
+	/** Toプロパティに対して値を含めて検索する*/
+	private boolean toConditionAsGreaterEqual;
 
 	/** 同値許容フラグ */
 	private boolean equivalentInput;
@@ -127,6 +133,21 @@ public class MetaDateRangePropertyEditor extends MetaCustomPropertyEditor implem
 		this.inputNullFrom = inputNullFrom;
 	}
 
+	/**
+	 * Fromプロパティに対して値を含めて検索するかを取得します。
+	 * @return Fromプロパティに対して値を含めて検索するか
+	 */
+	public boolean isFromConditionAsLesserEqual() {
+		return fromConditionAsLesserEqual;
+	}
+
+	/**
+	 * Fromプロパティに対して値を含めて検索するかを設定します。
+	 * @param fromConditionAsLesserEqual Fromプロパティに対して値を含めて検索するか
+	 */
+	public void setFromConditionAsLesserEqual(boolean fromConditionAsLesserEqual) {
+		this.fromConditionAsLesserEqual = fromConditionAsLesserEqual;
+	}
 
 	/**
 	 * Toプロパティエディタを取得します。
@@ -203,6 +224,22 @@ public class MetaDateRangePropertyEditor extends MetaCustomPropertyEditor implem
 	}
 
 	/**
+	 * Toプロパティに対して値を含めて検索するかを取得します。
+	 * @return Toプロパティに対して値を含めて検索するか
+	 */
+	public boolean isToConditionAsGreaterEqual() {
+		return toConditionAsGreaterEqual;
+	}
+
+	/**
+	 * Toプロパティに対して値を含めて検索するかを設定します。
+	 * @param toConditionAsGreaterEqual Toプロパティに対して値を含めて検索するか
+	 */
+	public void setToConditionAsGreaterEqual(boolean toConditionAsGreaterEqual) {
+		this.toConditionAsGreaterEqual = toConditionAsGreaterEqual;
+	}
+
+	/**
 	 * @return equivalentInput
 	 */
 	public boolean isEquivalentInput() {
@@ -264,7 +301,9 @@ public class MetaDateRangePropertyEditor extends MetaCustomPropertyEditor implem
 		}
 
 		setInputNullFrom(e.isInputNullFrom());
+		setFromConditionAsLesserEqual(e.isFromConditionAsLesserEqual());
 		setInputNullTo(e.isInputNullTo());
+		setToConditionAsGreaterEqual(e.isToConditionAsGreaterEqual());
 		setEquivalentInput(e.isEquivalentInput());
 
 		toPropertyId = convertId(e.getToPropertyName(), metaContext, entity);
@@ -308,7 +347,9 @@ public class MetaDateRangePropertyEditor extends MetaCustomPropertyEditor implem
 
 		_editor.setLocalizedToPropertyDisplayNameList(I18nUtil.toDef(localizedToPropertyDisplayNameList));
 		_editor.setInputNullFrom(inputNullFrom);
+		_editor.setFromConditionAsLesserEqual(fromConditionAsLesserEqual);
 		_editor.setInputNullTo(inputNullTo);
+		_editor.setToConditionAsGreaterEqual(toConditionAsGreaterEqual);
 		_editor.setEquivalentInput(equivalentInput);
 
 		_editor.setErrorMessage(errorMessage);

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaNumericRangePropertyEditor.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaNumericRangePropertyEditor.java
@@ -60,6 +60,9 @@ public class MetaNumericRangePropertyEditor extends MetaCustomPropertyEditor imp
 	/** FromのNull許容フラグ */
 	private boolean inputNullFrom;
 
+	/** Fromプロパティに対して値を含めて検索する*/
+	private boolean fromConditionAsLesserEqual = true;
+
 	/** Toプロパティエディタ */
 	private MetaPropertyEditor toEditor;
 
@@ -74,6 +77,9 @@ public class MetaNumericRangePropertyEditor extends MetaCustomPropertyEditor imp
 
 	/** ToのNull許容フラグ */
 	private boolean inputNullTo;
+
+	/** Toプロパティに対して値を含めて検索する*/
+	private boolean toConditionAsGreaterEqual;
 
 	/** 同値許容フラグ */
 	private boolean equivalentInput;
@@ -129,6 +135,22 @@ public class MetaNumericRangePropertyEditor extends MetaCustomPropertyEditor imp
 	 */
 	public void setInputNullFrom(boolean inputNullFrom) {
 		this.inputNullFrom = inputNullFrom;
+	}
+
+	/**
+	 * Fromプロパティに対して値を含めて検索するかを取得します。
+	 * @return Fromプロパティに対して値を含めて検索するか
+	 */
+	public boolean isFromConditionAsLesserEqual() {
+		return fromConditionAsLesserEqual;
+	}
+
+	/**
+	 * Fromプロパティに対して値を含めて検索するかを設定します。
+	 * @param fromConditionAsLesserEqual Fromプロパティに対して値を含めて検索するか
+	 */
+	public void setFromConditionAsLesserEqual(boolean fromConditionAsLesserEqual) {
+		this.fromConditionAsLesserEqual = fromConditionAsLesserEqual;
 	}
 
 	/**
@@ -206,6 +228,22 @@ public class MetaNumericRangePropertyEditor extends MetaCustomPropertyEditor imp
 	}
 
 	/**
+	 * Toプロパティに対して値を含めて検索するかを取得します。
+	 * @return Toプロパティに対して値を含めて検索するか
+	 */
+	public boolean isToConditionAsGreaterEqual() {
+		return toConditionAsGreaterEqual;
+	}
+
+	/**
+	 * Toプロパティに対して値を含めて検索するかを設定します。
+	 * @param toConditionAsGreaterEqual Toプロパティに対して値を含めて検索するか
+	 */
+	public void setToConditionAsGreaterEqual(boolean toConditionAsGreaterEqual) {
+		this.toConditionAsGreaterEqual = toConditionAsGreaterEqual;
+	}
+
+	/**
 	 * @return equivalentInput
 	 */
 	public boolean isEquivalentInput() {
@@ -267,7 +305,9 @@ public class MetaNumericRangePropertyEditor extends MetaCustomPropertyEditor imp
 		}
 
 		setInputNullFrom(e.isInputNullFrom());
+		setFromConditionAsLesserEqual(e.isFromConditionAsLesserEqual());
 		setInputNullTo(e.isInputNullTo());
+		setToConditionAsGreaterEqual(e.isToConditionAsGreaterEqual());
 		setEquivalentInput(e.isEquivalentInput());
 
 		toPropertyId = convertId(e.getToPropertyName(), metaContext, entity);
@@ -310,8 +350,11 @@ public class MetaNumericRangePropertyEditor extends MetaCustomPropertyEditor imp
 		}
 
 		_editor.setLocalizedToPropertyDisplayNameList(I18nUtil.toDef(localizedToPropertyDisplayNameList));
+
 		_editor.setInputNullFrom(inputNullFrom);
+		_editor.setFromConditionAsLesserEqual(fromConditionAsLesserEqual);
 		_editor.setInputNullTo(inputNullTo);
+		_editor.setToConditionAsGreaterEqual(toConditionAsGreaterEqual);
 		_editor.setEquivalentInput(equivalentInput);
 
 		_editor.setErrorMessage(errorMessage);

--- a/iplass-gem/src/main/java/org/iplass/mtp/view/generic/editor/DateRangePropertyEditor.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/view/generic/editor/DateRangePropertyEditor.java
@@ -88,6 +88,20 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	)
 	private boolean inputNullFrom;
 
+	/** Fromプロパティに対して値を含めて検索する*/
+	@MetaFieldInfo(
+			displayName="Fromプロパティに対して値を含めて検索する",
+			displayNameKey="generic_editor_DateRangePropertyEditor_fromConditionAsLesserEqualDisplayNameKey",
+			inputType=InputType.CHECKBOX,
+			displayOrder=108,
+			description="Fromプロパティに対して値を含めて検索するかを設定します。",
+			descriptionKey="generic_editor_DateRangePropertyEditor_fromConditionAsLesserEqualDescriptionKey"
+	)
+	@EntityViewField(
+			referenceTypes={FieldReferenceType.SEARCHCONDITION}
+	)
+	private boolean fromConditionAsLesserEqual = true;
+
 	/** Toプロパティ名 */
 	@MetaFieldInfo(displayName="Toプロパティ名",
 			displayNameKey="generic_editor_DateRangePropertyEditor_toPropertyNameDisplaNameKey",
@@ -163,6 +177,20 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	)
 	private boolean inputNullTo;
 
+	/** Toプロパティに対して値を含めて検索する*/
+	@MetaFieldInfo(
+			displayName="Toプロパティに対して値を含めて検索する",
+			displayNameKey="generic_editor_DateRangePropertyEditor_toConditionAsGreaterEqualDisplayNameKey",
+			inputType=InputType.CHECKBOX,
+			displayOrder=133,
+			description="Toプロパティに対して値を含めて検索するかを設定します。",
+			descriptionKey="generic_editor_DateRangePropertyEditor_toConditionAsGreaterEqualDescriptionKey"
+	)
+	@EntityViewField(
+			referenceTypes={FieldReferenceType.SEARCHCONDITION}
+	)
+	private boolean toConditionAsGreaterEqual;
+
 	/** 同値の入力を許容するか*/
 	@MetaFieldInfo(
 			displayName="同値の入力を許可",
@@ -224,6 +252,7 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	/**
 	 * @return editor
 	 */
+	@Override
 	public PropertyEditor getEditor() {
 		return editor;
 	}
@@ -250,8 +279,25 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	}
 
 	/**
+	 * Fromプロパティに対して値を含めて検索するかを取得します。
+	 * @return Fromプロパティに対して値を含めて検索するか
+	 */
+	public boolean isFromConditionAsLesserEqual() {
+		return fromConditionAsLesserEqual;
+	}
+
+	/**
+	 * Fromプロパティに対して値を含めて検索するかを設定します。
+	 * @param fromConditionAsLesserEqual Fromプロパティに対して値を含めて検索するか
+	 */
+	public void setFromConditionAsLesserEqual(boolean fromConditionAsLesserEqual) {
+		this.fromConditionAsLesserEqual = fromConditionAsLesserEqual;
+	}
+
+	/**
 	 * @return toEditor
 	 */
+	@Override
 	public PropertyEditor getToEditor() {
 		return toEditor;
 	}
@@ -266,6 +312,7 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	/**
 	 * @return toPropertyName
 	 */
+	@Override
 	public String getToPropertyName() {
 		return toPropertyName;
 	}
@@ -280,6 +327,7 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	/**
 	 * @return toPropertyDisplayName
 	 */
+	@Override
 	public String getToPropertyDisplayName() {
 		return toPropertyDisplayName;
 	}
@@ -295,6 +343,7 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	 * Toプロパティ表示名の多言語設定情報を取得します。
 	 * @return リスト
 	 */
+	@Override
 	public List<LocalizedStringDefinition> getLocalizedToPropertyDisplayNameList() {
 		return localizedToPropertyDisplayNameList;
 	}
@@ -322,6 +371,22 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	}
 
 	/**
+	 * Toプロパティに対して値を含めて検索するかを取得します。
+	 * @return Toプロパティに対して値を含めて検索するか
+	 */
+	public boolean isToConditionAsGreaterEqual() {
+		return toConditionAsGreaterEqual;
+	}
+
+	/**
+	 * Toプロパティに対して値を含めて検索するかを設定します。
+	 * @param toConditionAsGreaterEqual Toプロパティに対して値を含めて検索するか
+	 */
+	public void setToConditionAsGreaterEqual(boolean toConditionAsGreaterEqual) {
+		this.toConditionAsGreaterEqual = toConditionAsGreaterEqual;
+	}
+
+	/**
 	 * @return equivalentInput
 	 */
 	public boolean isEquivalentInput() {
@@ -339,6 +404,7 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	/**
 	 * @return errorMessage
 	 */
+	@Override
 	public String getErrorMessage() {
 		return errorMessage;
 	}
@@ -353,6 +419,7 @@ public class DateRangePropertyEditor extends CustomPropertyEditor implements Ran
 	/**
 	 * @return localizedErrorMessageList
 	 */
+	@Override
 	public List<LocalizedStringDefinition> getLocalizedErrorMessageList() {
 		return localizedErrorMessageList;
 	}

--- a/iplass-gem/src/main/java/org/iplass/mtp/view/generic/editor/NumericRangePropertyEditor.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/view/generic/editor/NumericRangePropertyEditor.java
@@ -93,6 +93,20 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	)
 	private boolean inputNullFrom;
 
+	/** Fromプロパティに対して値を含めて検索する*/
+	@MetaFieldInfo(
+			displayName="Fromプロパティに対して値を含めて検索する",
+			displayNameKey="generic_editor_NumericRangePropertyEditor_fromConditionAsLesserEqualDisplayNameKey",
+			inputType=InputType.CHECKBOX,
+			displayOrder=108,
+			description="Fromプロパティに対して値を含めて検索するかを設定します。",
+			descriptionKey="generic_editor_NumericRangePropertyEditor_fromConditionAsLesserEqualDescriptionKey"
+	)
+	@EntityViewField(
+			referenceTypes={FieldReferenceType.SEARCHCONDITION}
+	)
+	private boolean fromConditionAsLesserEqual = true;
+
 	/** Toプロパティ名 */
 	@MetaFieldInfo(displayName="Toプロパティ名",
 			displayNameKey="generic_editor_NumericRangePropertyEditor_toPropertyNameDisplaNameKey",
@@ -168,6 +182,20 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	)
 	private boolean inputNullTo;
 
+	/** Toプロパティに対して値を含めて検索する*/
+	@MetaFieldInfo(
+			displayName="Toプロパティに対して値を含めて検索する",
+			displayNameKey="generic_editor_NumericRangePropertyEditor_toConditionAsGreaterEqualDisplayNameKey",
+			inputType=InputType.CHECKBOX,
+			displayOrder=133,
+			description="Toプロパティに対して値を含めて検索するかを設定します。",
+			descriptionKey="generic_editor_NumericRangePropertyEditor_toConditionAsGreaterEqualDescriptionKey"
+	)
+	@EntityViewField(
+			referenceTypes={FieldReferenceType.SEARCHCONDITION}
+	)
+	private boolean toConditionAsGreaterEqual;
+
 	/** 同値の入力を許容するか*/
 	@MetaFieldInfo(
 			displayName="同値の入力を許可",
@@ -232,6 +260,7 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	/**
 	 * @return editor
 	 */
+	@Override
 	public PropertyEditor getEditor() {
 		return editor;
 	}
@@ -258,8 +287,25 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	}
 
 	/**
+	 * Fromプロパティに対して値を含めて検索するかを取得します。
+	 * @return Fromプロパティに対して値を含めて検索するか
+	 */
+	public boolean isFromConditionAsLesserEqual() {
+		return fromConditionAsLesserEqual;
+	}
+
+	/**
+	 * Fromプロパティに対して値を含めて検索するかを設定します。
+	 * @param fromConditionAsLesserEqual Fromプロパティに対して値を含めて検索するか
+	 */
+	public void setFromConditionAsLesserEqual(boolean fromConditionAsLesserEqual) {
+		this.fromConditionAsLesserEqual = fromConditionAsLesserEqual;
+	}
+
+	/**
 	 * @return toEditor
 	 */
+	@Override
 	public PropertyEditor getToEditor() {
 		return toEditor;
 	}
@@ -274,6 +320,7 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	/**
 	 * @return toPropertyName
 	 */
+	@Override
 	public String getToPropertyName() {
 		return toPropertyName;
 	}
@@ -288,6 +335,7 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	/**
 	 * @return toPropertyDisplayName
 	 */
+	@Override
 	public String getToPropertyDisplayName() {
 		return toPropertyDisplayName;
 	}
@@ -303,6 +351,7 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	 * Toプロパティ表示名の多言語設定情報を取得します。
 	 * @return リスト
 	 */
+	@Override
 	public List<LocalizedStringDefinition> getLocalizedToPropertyDisplayNameList() {
 		return localizedToPropertyDisplayNameList;
 	}
@@ -330,6 +379,22 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	}
 
 	/**
+	 * Toプロパティに対して値を含めて検索するかを取得します。
+	 * @return Toプロパティに対して値を含めて検索するか
+	 */
+	public boolean isToConditionAsGreaterEqual() {
+		return toConditionAsGreaterEqual;
+	}
+
+	/**
+	 * Toプロパティに対して値を含めて検索するかを設定します。
+	 * @param toConditionAsGreaterEqual Toプロパティに対して値を含めて検索するか
+	 */
+	public void setToConditionAsGreaterEqual(boolean toConditionAsGreaterEqual) {
+		this.toConditionAsGreaterEqual = toConditionAsGreaterEqual;
+	}
+
+	/**
 	 * @return equivalentInput
 	 */
 	public boolean isEquivalentInput() {
@@ -346,6 +411,7 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	/**
 	 * @return errorMessage
 	 */
+	@Override
 	public String getErrorMessage() {
 		return errorMessage;
 	}
@@ -360,6 +426,7 @@ public class NumericRangePropertyEditor extends CustomPropertyEditor implements 
 	/**
 	 * @return localizedErrorMessageList
 	 */
+	@Override
 	public List<LocalizedStringDefinition> getLocalizedErrorMessageList() {
 		return localizedErrorMessageList;
 	}


### PR DESCRIPTION
https://github.com/ISID/iPLAss/issues/1314 対応