### PR TITLE
GEM、検索結果のCSVダウンロードでReferencePropertyEditorの「表示ラベルとして扱うプロパティ」を考慮する

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/GemConfigService.java
@@ -108,6 +108,9 @@ public class GemConfigService implements Service {
 	/** 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するか */
 	private boolean useDisplayLabelItemInSearch;
 
+	/** CSVダウンロード処理で表示ラベルとして扱うプロパティを出力するか */
+	private boolean useDisplayLabelItemInCsvDownload;
+
 	/** プルダウンの「選択してください」を表示するか */
 	private boolean showPulldownPleaseSelectLabel;
 
@@ -207,6 +210,8 @@ public class GemConfigService implements Service {
 		}
 
 		useDisplayLabelItemInSearch = config.getValue("useDisplayLabelItemInSearch", Boolean.class, false);
+
+		useDisplayLabelItemInCsvDownload = config.getValue("useDisplayLabelItemInCsvDownload", Boolean.class, false);
 
 		showPulldownPleaseSelectLabel = config.getValue("showPulldownPleaseSelectLabel", Boolean.class, true);
 
@@ -438,6 +443,14 @@ public class GemConfigService implements Service {
 	 */
 	public boolean isUseDisplayLabelItemInSearch() {
 		return useDisplayLabelItemInSearch;
+	}
+
+	/**
+	 * CSVダウンロード処理で表示ラベルとして扱うプロパティを出力するかを取得します。
+	 * @return CSVダウンロード処理で表示ラベルとして扱うプロパティを出力するか
+	 */
+	public boolean isUseDisplayLabelItemInCsvDownload() {
+		return useDisplayLabelItemInCsvDownload;
 	}
 
 	/**

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/CsvDownloadSearchContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/CsvDownloadSearchContext.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.iplass.gem.GemConfigService;
 import org.iplass.gem.command.Constants;
 import org.iplass.gem.command.GemResourceBundleUtil;
 import org.iplass.mtp.ApplicationException;
@@ -46,6 +47,7 @@ import org.iplass.mtp.entity.query.Query;
 import org.iplass.mtp.entity.query.Select;
 import org.iplass.mtp.entity.query.Where;
 import org.iplass.mtp.impl.entity.csv.EntityCsvException;
+import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.utilityclass.definition.UtilityClassDefinitionManager;
 import org.iplass.mtp.view.generic.EntityView;
@@ -443,9 +445,24 @@ public class CsvDownloadSearchContext extends SearchContextBase {
 						oidColumn.setColumnLabel(getColumnLabel(oidColumn));
 						columnMap.putIfAbsent(oidColumn.getPropertyName(), oidColumn);
 					}
-					CsvColumn csvColumn = new CsvColumn(propertyName + "." + Entity.NAME);
+
+					GemConfigService service = ServiceRegistry.getRegistry().getService(GemConfigService.class);
+					String displayLabelItem = ((ReferencePropertyEditor)csvItem.getEditor()).getDisplayLabelItem();
+					
+					CsvColumn csvColumn = null;
+					if (service.isUseDisplayLabelItemInCsvDownload() && StringUtil.isNotBlank(displayLabelItem)) {
+						//表示ラベルとして扱うプロパティが設定されたら表示ラベルを利用する
+						csvColumn = new CsvColumn(propertyName + "." + displayLabelItem);
+					} else {
+						csvColumn = new CsvColumn(propertyName + "." + Entity.NAME);
+					}
 					csvColumn.setReferenceProperty(pd);
-					csvColumn.setPropertyDefinition(red.getProperty(Entity.NAME));
+					if (service.isUseDisplayLabelItemInCsvDownload() && StringUtil.isNotBlank(displayLabelItem)) {
+						//表示ラベルとして扱うプロパティが設定されたら表示ラベルを利用する
+						csvColumn.setPropertyDefinition(red.getProperty(displayLabelItem));
+					} else {
+						csvColumn.setPropertyDefinition(red.getProperty(Entity.NAME));
+					}
 					csvColumn.setCsvItem(csvItem);
 					csvColumn.setColumnLabel(getColumnLabel(csvColumn));
 					columnMap.putIfAbsent(csvColumn.getPropertyName(), csvColumn);

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/CsvDownloadSearchContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/CsvDownloadSearchContext.java
@@ -453,16 +453,12 @@ public class CsvDownloadSearchContext extends SearchContextBase {
 					if (service.isUseDisplayLabelItemInCsvDownload() && StringUtil.isNotBlank(displayLabelItem)) {
 						//表示ラベルとして扱うプロパティが設定されたら表示ラベルを利用する
 						csvColumn = new CsvColumn(propertyName + "." + displayLabelItem);
-					} else {
-						csvColumn = new CsvColumn(propertyName + "." + Entity.NAME);
-					}
-					csvColumn.setReferenceProperty(pd);
-					if (service.isUseDisplayLabelItemInCsvDownload() && StringUtil.isNotBlank(displayLabelItem)) {
-						//表示ラベルとして扱うプロパティが設定されたら表示ラベルを利用する
 						csvColumn.setPropertyDefinition(red.getProperty(displayLabelItem));
 					} else {
+						csvColumn = new CsvColumn(propertyName + "." + Entity.NAME);
 						csvColumn.setPropertyDefinition(red.getProperty(Entity.NAME));
 					}
+					csvColumn.setReferenceProperty(pd);
 					csvColumn.setCsvItem(csvItem);
 					csvColumn.setColumnLabel(getColumnLabel(csvColumn));
 					columnMap.putIfAbsent(csvColumn.getPropertyName(), csvColumn);

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/CsvDownloadSearchContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/CsvDownloadSearchContext.java
@@ -658,7 +658,13 @@ public class CsvDownloadSearchContext extends SearchContextBase {
 			CsvItem csvItem = csvColumn.getCsvItem();
 			if (!StringUtil.isEmpty(csvItem.getDisplayLabel())) {
 				String displayLabel = TemplateUtil.getMultilingualString(csvItem.getDisplayLabel(), csvItem.getLocalizedDisplayLabelList());
-				if (displayLabel != null) return displayLabel;
+				if (displayLabel != null) {
+					if (csvColumn.getReferenceProperty() != null && csvColumn.getPropertyDefinition().getName().equals(Entity.OID)) {
+						return displayLabel + "(ID)";
+					} else {
+						return displayLabel;
+					}
+				}
 			}
 		}
 

--- a/iplass-gem/src/main/resources/gem-service-config.xml
+++ b/iplass-gem/src/main/resources/gem-service-config.xml
@@ -134,6 +134,9 @@
 		<!-- 検索処理で表示ラベルとして扱うプロパティを検索条件に利用するか -->
 		<property name="useDisplayLabelItemInSearch" value="false"/>
 
+		<!-- CSVダウンロード処理で表示ラベルとして扱うプロパティを出力するか -->
+		<property name="useDisplayLabelItemInCsvDownload" value="false"/>
+
 		<!-- CSVアップロード非同期設定 -->
 		<!-- true(非同期)を設定する場合は、 RdbQueueServiceのuseQueueプロパティをtrueに設定してください。 -->
 		<property name="csvUploadAsync" value="false"/>


### PR DESCRIPTION
GEM、検索結果のCSVダウンロードでReferencePropertyEditorの「表示ラベルとして扱うプロパティ」を考慮する。
ReferencePropertyEditorで「表示ラベルとして扱うプロパティ」として設定された項目をCSVダウンロード時にCSV項目として出力する。

後方互換性を保つため、GemConfigServiceにフラグを追加し、挙動を変更できるようにする（デフォルトでは、現状の挙動のまま）。