### PR TITLE
NestTableの追加時にSelect型のitemnameがindex値に変更されていないため対応

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
@@ -3900,6 +3900,11 @@ function addNestRow(rowId, countId, multiplicy, insertTop, rootDefName, viewName
 					var token = $(this).attr("token");
 					uploadFile(this, token);
 				});
+			} else if (type[0] == "Select") {
+				//Select
+				$td.children("ul").each(function() {
+					replaceDummyAttr(this, "data-itemname", idx);
+				});
 			} else if (type[0] == "Reference") {
 				//参照
 				addNestRow_Reference(type[1], $td, idx);


### PR DESCRIPTION
https://github.com/ISID/iPLAss/issues/1329 対応。

連動リンクで利用される、連動元の `itemname` の変換漏れ対応。
NestTableでの追加処理時に、 `Dummy` となっている `itemname` をindex値に置き換える。