### PR TITLE
gem、ReferencePropertyEditorのCheckboxタイプを連動元にした場合に、連動プロパティが制御されない（3.1）

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
@@ -856,7 +856,7 @@ $(function() {
 <%
 		} else {
 %>
-<ul class="<c:out value="<%=cls %>"/>">
+<ul class="<c:out value="<%=cls %>"/>" data-itemName="<c:out value="<%=propName %>"/>">
 <%
 			for (Entity refEntity : entityList) {
 %>


### PR DESCRIPTION
https://github.com/ISID/iPLAss/issues/1348 対応