### PR TITLE
WebApiとActionMappingのアノテーションのタイプミス修正

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/action/ActionAttributePane.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/action/ActionAttributePane.java
@@ -59,7 +59,7 @@ public class ActionAttributePane extends HLayout {
 	/** 部品（直接呼び出し不可） */
 	private CheckboxItem partsField;
 	/** 特権実行（セキュリティ制約を受けない） */
-	private CheckboxItem privilagedField;
+	private CheckboxItem privilegedField;
 	/** 公開Action */
 	private CheckboxItem publicActionField;
 	/** sessionにて同期を行うか否か */
@@ -121,9 +121,9 @@ public class ActionAttributePane extends HLayout {
 		partsField.setShowTitle(false);
 		partsField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_errDirectAccess")));
 
-		privilagedField = new CheckboxItem("privilaged", "privilege execute");
-		privilagedField.setShowTitle(false);
-		privilagedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_privilExecution")));
+		privilegedField = new CheckboxItem("privileged", "privilege execute");
+		privilegedField.setShowTitle(false);
+		privilegedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_privilExecution")));
 
 		publicActionField = new CheckboxItem("publicActionField", "public action");
 		publicActionField.setShowTitle(false);
@@ -137,7 +137,7 @@ public class ActionAttributePane extends HLayout {
 		needTrustedAuthenticateField.setShowTitle(false);
 		needTrustedAuthenticateField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_needTrustedAuthenticate")));
 
-		accessForm.setItems(partsField, privilagedField, publicActionField, synchronizeOnSessionField, needTrustedAuthenticateField);
+		accessForm.setItems(partsField, privilegedField, publicActionField, synchronizeOnSessionField, needTrustedAuthenticateField);
 
 
 		tokenForm = new DynamicForm();
@@ -249,7 +249,7 @@ public class ActionAttributePane extends HLayout {
 		}
 
 		partsField.setValue(definition.isParts());
-		privilagedField.setValue(definition.isPrivilaged());
+		privilegedField.setValue(definition.isPrivileged());
 		publicActionField.setValue(definition.isPublicAction());
 		synchronizeOnSessionField.setValue(definition.isSynchronizeOnSession());
 		needTrustedAuthenticateField.setValue(definition.isNeedTrustedAuthenticate());
@@ -308,7 +308,7 @@ public class ActionAttributePane extends HLayout {
 		definition.setAllowMethod(methodType);
 
 		definition.setParts(SmartGWTUtil.getBooleanValue(partsField));
-		definition.setPrivilaged(SmartGWTUtil.getBooleanValue(privilagedField));
+		definition.setPrivileged(SmartGWTUtil.getBooleanValue(privilegedField));
 		definition.setPublicAction(SmartGWTUtil.getBooleanValue(publicActionField));
 		definition.setSynchronizeOnSession(SmartGWTUtil.getBooleanValue(synchronizeOnSessionField));
 		definition.setNeedTrustedAuthenticate(SmartGWTUtil.getBooleanValue(needTrustedAuthenticateField));

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/webapi/WebApiAttributePane.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/webapi/WebApiAttributePane.java
@@ -62,7 +62,7 @@ public class WebApiAttributePane extends HLayout {
 	private CheckboxItem deleteMethod;
 
 	/** 特権実行（セキュリティ制約を受けない） */
-	private CheckboxItem privilagedField;
+	private CheckboxItem privilegedField;
 
 	/** 公開WebAPI */
 	private CheckboxItem publicWebAPIField;
@@ -123,8 +123,8 @@ public class WebApiAttributePane extends HLayout {
 		accessForm.setIsGroup(true);
 		accessForm.setGroupTitle("Access Policy");
 
-		privilagedField = new CheckboxItem("privilaged", "Privilege execute");
-		privilagedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_webapi_WebAPIAttributePane_privilExecution")));
+		privilegedField = new CheckboxItem("privileged", "Privilege execute");
+		privilegedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_webapi_WebAPIAttributePane_privilExecution")));
 
 		publicWebAPIField = new CheckboxItem("publicWebAPI", "Public WebAPI");
 		publicWebAPIField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_webapi_WebAPIAttributePane_publicWebAPI")));
@@ -145,7 +145,7 @@ public class WebApiAttributePane extends HLayout {
 		stateTypeMap.put(StateType.STATELESS.toString(), StateType.STATELESS.toString());
 		stateTypeField.setValueMap(stateTypeMap);
 
-		accessForm.setItems(privilagedField, publicWebAPIField, checkXRequestedWithHeaderField,
+		accessForm.setItems(privilegedField, publicWebAPIField, checkXRequestedWithHeaderField,
 				synchronizeOnSessionField, stateTypeField);
 
 		tokenForm = new DynamicForm();
@@ -245,7 +245,7 @@ public class WebApiAttributePane extends HLayout {
 			}
 		}
 
-		privilagedField.setValue(definition.isPrivilaged());
+		privilegedField.setValue(definition.isPrivileged());
 		publicWebAPIField.setValue(definition.isPublicWebApi());
 		checkXRequestedWithHeaderField.setValue(definition.isCheckXRequestedWithHeader());
 		synchronizeOnSessionField.setValue(definition.isSynchronizeOnSession());
@@ -309,7 +309,7 @@ public class WebApiAttributePane extends HLayout {
 			i++;
 		}
 		definition.setMethods(methodType);
-		definition.setPrivilaged(SmartGWTUtil.getBooleanValue(privilagedField));
+		definition.setPrivileged(SmartGWTUtil.getBooleanValue(privilegedField));
 		definition.setPublicWebApi(SmartGWTUtil.getBooleanValue(publicWebAPIField));
 		definition.setCheckXRequestedWithHeader(SmartGWTUtil.getBooleanValue(checkXRequestedWithHeaderField));
 		definition.setSynchronizeOnSession(SmartGWTUtil.getBooleanValue(synchronizeOnSessionField));

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/cache/QueryCacheInterceptor.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/cache/QueryCacheInterceptor.java
@@ -20,6 +20,7 @@
 package org.iplass.mtp.impl.entity.cache;
 
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 
 import org.iplass.mtp.entity.Entity;
@@ -172,7 +173,11 @@ class QueryCacheInterceptor extends EntityInterceptorAdapter {
 							invocation.proceed();
 
 							QueryCache qc = new QueryCache(list.size(), list, invocation.getType(), hint.getTTL());
-							return new CacheEntry(new QueryCacheKey(q.copy(), invocation.getSearchOption().isReturnStructuredEntity()), qc, (Object) usedEntityDefs);
+							CacheEntry newCe = new CacheEntry(new QueryCacheKey(q.copy(), invocation.getSearchOption().isReturnStructuredEntity()), qc, (Object) usedEntityDefs);
+							if (hint.getTTL() > 0) {
+								newCe.setTimeToLive(TimeUnit.SECONDS.toMillis(hint.getTTL()));
+							}
+							return newCe;
 						} else {
 							if (logger.isTraceEnabled()) {
 								logger.trace("Result list from global cache:" + q);
@@ -236,7 +241,11 @@ class QueryCacheInterceptor extends EntityInterceptorAdapter {
 					if (isInvalidCountCache(v)) {
 						int ret = invocation.proceed();
 						QueryCache qc = new QueryCache(ret, null, invocation.getType(), hint.getTTL());
-						return new CacheEntry(new QueryCacheKey(q.copy(), false), qc, (Object) usedEntityDefs);
+						CacheEntry newCe = new CacheEntry(new QueryCacheKey(q.copy(), false), qc, (Object) usedEntityDefs);
+						if (hint.getTTL() > 0) {
+							newCe.setTimeToLive(TimeUnit.SECONDS.toMillis(hint.getTTL()));
+						}
+						return newCe;
 					} else {
 						if (logger.isTraceEnabled()) {
 							logger.trace("Result list from global cache:" + q);

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/oracle/OracleDateRdbTypeAdapter.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/rdb/oracle/OracleDateRdbTypeAdapter.java
@@ -45,9 +45,13 @@ public class OracleDateRdbTypeAdapter extends BaseRdbTypeAdapter.Date {
 	public void setParameter(int index, Object javaTypeValue,
 			PreparedStatement stmt, RdbAdapter rdb) throws SQLException {
 		java.sql.Date val = toRdb(javaTypeValue, rdb);
-		SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
-		String dateStr = fmt.format(val);
-		stmt.setString(index, dateStr);
+		if (val != null) {
+			SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
+			String dateStr = fmt.format(val);
+			stmt.setString(index, dateStr);
+		} else {
+			stmt.setString(index, null);
+		}
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/gem/command/auth/LoginCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/auth/LoginCommand.java
@@ -57,13 +57,13 @@ import org.slf4j.LoggerFactory;
 @ActionMappings({
 	@ActionMapping(name=LoginCommand.ACTION_VIEW_LOGIN,
 			clientCacheType=ClientCacheType.NO_CACHE,
-			privilaged=true,
+			privileged=true,
 			command={},
 			result=@Result(type=Type.TEMPLATE, value=Constants.TEMPLATE_LOGIN)),
 	@ActionMapping(name=LoginCommand.ACTION_LOGIN,
 			allowMethod=HttpMethodType.POST,
 			clientCacheType=ClientCacheType.NO_CACHE,
-			privilaged=true,
+			privileged=true,
 			result={
 				@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.REDIRECT, value="mtp.auth.redirectPath"),
 				@Result(status=LoginCommand.CMD_EXEC_EXPIRE, type=Type.TEMPLATE, value=Constants.TEMPLATE_PASSWORD_EXPIRE),

--- a/iplass-gem/src/main/java/org/iplass/gem/command/auth/LogoutCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/auth/LogoutCommand.java
@@ -33,7 +33,7 @@ import org.iplass.mtp.web.template.TemplateUtil;
 
 @ActionMapping(name=LogoutCommand.ACTION_LOOUT,
 		clientCacheType=ClientCacheType.NO_CACHE,
-		privilaged=true,
+		privileged=true,
 		result={@Result(status="SUCCESS", type=Type.REDIRECT, value=LogoutCommand.RESULT_REDIRECT_PATH)
 })
 @CommandClass(name="gem/auth/LogoutCommand", displayName="ログアウト処理")

--- a/iplass-gem/src/main/java/org/iplass/gem/command/auth/UpdateExpirePasswordCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/auth/UpdateExpirePasswordCommand.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 @ActionMapping(name=UpdateExpirePasswordCommand.ACTION_UPDATE_EXP_PASSWORD,
 		allowMethod=HttpMethodType.POST,
 		clientCacheType=ClientCacheType.NO_CACHE,
-		privilaged=true,
+		privileged=true,
 		command=@CommandConfig("cmd.checkLoginToken=true"),
 		result={
 			@Result(status="SUCCESS", type=Type.REDIRECT, value="mtp.auth.redirectPath"),

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/MtpBatchResourceDisposer.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/MtpBatchResourceDisposer.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.tools.batch;
+
+import java.util.Optional;
+
+import org.iplass.mtp.impl.core.TenantContextService;
+import org.iplass.mtp.spi.ServiceRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * バッチ処理用リソース破棄処理
+ *
+ * <p>
+ * バッチ処理でリソースを破棄するための処理を集約します。
+ * </p>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public class MtpBatchResourceDisposer {
+	/** ロガー */
+	private static final Logger LOG = LoggerFactory.getLogger(MtpBatchResourceDisposer.class);
+
+	/**
+	 * プライベートコンストラクタ
+	 */
+	private MtpBatchResourceDisposer() {
+		// NOP
+	}
+
+	/**
+	 * リソース破棄処理の Shutdown Hook 追加
+	 *
+	 * <p>
+	 * GUIの場合のリソース破棄は、Runtime.addShutdownHook で実施する。
+	 * {@link #disposeResource()} は shutdown hook スレッドの最後でコールする。
+	 * </p>
+	 *
+	 * <p>
+	 * 終了時点の処理になるので、インスタンスの状態に注意してメソッドを実装すること。
+	 * </p>
+	 */
+	public static void addShutdownHookForDisposeResource(Runnable disposeProcess) {
+		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+			LOG.info("Begin resource dispose by shutdown hook.");
+			try {
+				Optional.ofNullable(disposeProcess).ifPresent(r -> r.run());
+			} finally {
+				// リソース破棄
+				disposeResource();
+			}
+		}));
+	}
+
+	/**
+	 * リソース破棄処理
+	 */
+	public static void disposeResource() {
+		LOG.info("Destroy all services.");
+		// 全サービス破棄。全サービス破棄に先立ち、TenantContextService 破棄する
+		// （TenantContext で管理している TenantResource 実装クラスが Service クラスに依存している可能性がある為）
+		ServiceRegistry.getRegistry().getService(TenantContextService.class).destroy();
+		ServiceRegistry.getRegistry().destroyAllService();
+	}
+}

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/AsyncTaskCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/AsyncTaskCleaner.java
@@ -11,6 +11,7 @@ import org.iplass.mtp.impl.core.ExecuteContext;
 import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
@@ -46,16 +47,22 @@ public class AsyncTaskCleaner extends MtpSilentBatch {
 		if (args != null && args.length > 0 && StringUtil.isNotEmpty(args[0])) {
 			tenantId = Integer.parseInt(args[0]);
 		}
-		if (tenantId >= 0) {
-			(new AsyncTaskCleaner(tenantId)).clean();
-		} else {
-			//全テナントを対象
-			List<TenantInfo> tenants = getValidTenantInfoList();
-			if (tenants != null) {
-				for (TenantInfo t: tenants) {
-					(new AsyncTaskCleaner(t.getId())).clean();
+
+		try {
+			if (tenantId >= 0) {
+				(new AsyncTaskCleaner(tenantId)).clean();
+			} else {
+				//全テナントを対象
+				List<TenantInfo> tenants = getValidTenantInfoList();
+				if (tenants != null) {
+					for (TenantInfo t: tenants) {
+						(new AsyncTaskCleaner(t.getId())).clean();
+					}
 				}
 			}
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/AuthProviderCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/AuthProviderCleaner.java
@@ -12,6 +12,7 @@ import org.iplass.mtp.impl.core.ExecuteContext;
 import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
@@ -45,16 +46,22 @@ public class AuthProviderCleaner extends MtpSilentBatch {
 		if (args != null && args.length > 0 && StringUtil.isNotEmpty(args[0])) {
 			tenantId = Integer.parseInt(args[0]);
 		}
-		if (tenantId >= 0) {
-			(new AuthProviderCleaner(tenantId)).clean();
-		} else {
-			//全テナントを対象
-			List<TenantInfo> tenants = getValidTenantInfoList();
-			if (tenants != null) {
-				for (TenantInfo t: tenants) {
-					(new AuthProviderCleaner(t.getId())).clean();
+
+		try {
+			if (tenantId >= 0) {
+				(new AuthProviderCleaner(tenantId)).clean();
+			} else {
+				//全テナントを対象
+				List<TenantInfo> tenants = getValidTenantInfoList();
+				if (tenants != null) {
+					for (TenantInfo t: tenants) {
+						(new AuthProviderCleaner(t.getId())).clean();
+					}
 				}
 			}
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/InvalidMetaDataCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/InvalidMetaDataCleaner.java
@@ -14,6 +14,7 @@ import org.iplass.mtp.impl.metadata.MetaDataEntryInfo;
 import org.iplass.mtp.impl.metadata.MetaDataRepository;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
@@ -49,16 +50,22 @@ public class InvalidMetaDataCleaner extends MtpSilentBatch {
 		if (args != null && args.length > 0 && StringUtil.isNotEmpty(args[0])) {
 			tenantId = Integer.parseInt(args[0]);
 		}
-		if (tenantId >= 0) {
-			(new InvalidMetaDataCleaner(tenantId)).clean();
-		} else {
-			//全テナントを対象
-			List<TenantInfo> tenants = getValidTenantInfoList();
-			if (tenants != null) {
-				for (TenantInfo t: tenants) {
-					(new InvalidMetaDataCleaner(t.getId())).clean();
+		
+		try {
+			if (tenantId >= 0) {
+				(new InvalidMetaDataCleaner(tenantId)).clean();
+			} else {
+				//全テナントを対象
+				List<TenantInfo> tenants = getValidTenantInfoList();
+				if (tenants != null) {
+					for (TenantInfo t: tenants) {
+						(new InvalidMetaDataCleaner(t.getId())).clean();
+					}
 				}
 			}
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/RbCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/RbCleaner.java
@@ -14,6 +14,7 @@ import org.iplass.mtp.impl.entity.EntityService;
 import org.iplass.mtp.impl.tools.clean.RecycleBinCleanService;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
@@ -56,15 +57,21 @@ public class RbCleaner extends MtpSilentBatch {
 		if (args != null && args.length > 0 && StringUtil.isNotEmpty(args[0])) {
 			tenantId = Integer.parseInt(args[0]);
 		}
-		if (tenantId >= 0) {
-			(new RbCleaner(tenantId)).clean(purgeTargetDate);
-		} else {
-			List<TenantInfo> tenants = getValidTenantInfoList();
-			if (tenants != null) {
-				for (TenantInfo t: tenants) {
-					(new RbCleaner(t.getId())).clean(purgeTargetDate);
+		
+		try {
+			if (tenantId >= 0) {
+				(new RbCleaner(tenantId)).clean(purgeTargetDate);
+			} else {
+				List<TenantInfo> tenants = getValidTenantInfoList();
+				if (tenants != null) {
+					for (TenantInfo t: tenants) {
+						(new RbCleaner(t.getId())).clean(purgeTargetDate);
+					}
 				}
 			}
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/RdbCacheCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/RdbCacheCleaner.java
@@ -8,6 +8,7 @@ import org.iplass.mtp.impl.cache.store.builtin.RdbCacheStoreFactory;
 import org.iplass.mtp.impl.core.ExecuteContext;
 import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,12 @@ public class RdbCacheCleaner extends MtpSilentBatch {
 	private static TenantContextService tenantContextService = ServiceRegistry.getRegistry().getService(TenantContextService.class);
 
 	public static void main(String[] args) throws Exception {
-		new RdbCacheCleaner().clean();
+		try {
+			new RdbCacheCleaner().clean();
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
+		}
 	}
 
 	public RdbCacheCleaner() {

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/TempLobCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/TempLobCleaner.java
@@ -11,6 +11,7 @@ import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.impl.lob.LobHandler;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
@@ -39,15 +40,21 @@ public class TempLobCleaner extends MtpSilentBatch {
 		if (args != null && args.length > 0 && StringUtil.isNotEmpty(args[0])) {
 			tenantId = Integer.parseInt(args[0]);
 		}
-		if (tenantId >= 0) {
-			(new TempLobCleaner(tenantId)).clean();
-		} else {
-			List<TenantInfo> tenants = getValidTenantInfoList();
-			if (tenants != null) {
-				for (TenantInfo t: tenants) {
-					(new TempLobCleaner(t.getId())).clean();
+
+		try {
+			if (tenantId >= 0) {
+				(new TempLobCleaner(tenantId)).clean();
+			} else {
+				List<TenantInfo> tenants = getValidTenantInfoList();
+				if (tenants != null) {
+					for (TenantInfo t: tenants) {
+						(new TempLobCleaner(t.getId())).clean();
+					}
 				}
 			}
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/TempUserCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/cleaner/TempUserCleaner.java
@@ -17,6 +17,7 @@ import org.iplass.mtp.impl.core.ExecuteContext;
 import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
@@ -53,15 +54,21 @@ public class TempUserCleaner extends MtpSilentBatch {
 		if (args != null && args.length > 0 && StringUtil.isNotEmpty(args[0])) {
 			tenantId = Integer.parseInt(args[0]);
 		}
-		if (tenantId >= 0) {
-			(new TempUserCleaner(tenantId)).clean();
-		} else {
-			List<TenantInfo> tenants = getValidTenantInfoList();
-			if (tenants != null) {
-				for (TenantInfo t: tenants) {
-					(new TempUserCleaner(t.getId())).clean();
+		
+		try {
+			if (tenantId >= 0) {
+				(new TempUserCleaner(tenantId)).clean();
+			} else {
+				List<TenantInfo> tenants = getValidTenantInfoList();
+				if (tenants != null) {
+					for (TenantInfo t: tenants) {
+						(new TempUserCleaner(t.getId())).clean();
+					}
 				}
 			}
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/config/ServiceConfigViewer.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/config/ServiceConfigViewer.java
@@ -35,6 +35,7 @@ import org.iplass.mtp.impl.core.config.BootstrapProps;
 import org.iplass.mtp.impl.core.config.ServiceDefinition;
 import org.iplass.mtp.impl.core.config.ServiceDefinitionParser;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.util.StringUtil;
 
 public class ServiceConfigViewer {
@@ -92,6 +93,9 @@ public class ServiceConfigViewer {
 			new ServiceConfigViewer(args).execute();
 		} catch (Exception e) {
 			e.printStackTrace();
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EQLExecutor.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EQLExecutor.java
@@ -33,6 +33,7 @@ import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.impl.tools.entity.EntityToolService;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,6 +128,9 @@ public class EQLExecutor extends MtpCuiBase {
 			new EQLExecutor(args).execute();
 		} catch (Exception e) {
 			e.printStackTrace();
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityDeleteAll.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityDeleteAll.java
@@ -35,6 +35,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
@@ -94,6 +95,8 @@ public class EntityDeleteAll extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityExport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityExport.java
@@ -50,6 +50,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
@@ -117,6 +118,8 @@ public class EntityExport extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityImport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityImport.java
@@ -58,6 +58,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
@@ -132,6 +133,8 @@ public class EntityImport extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityJavaMappingClassCreator.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityJavaMappingClassCreator.java
@@ -34,6 +34,7 @@ import org.iplass.mtp.impl.tools.entity.EntityToolService;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,6 +118,9 @@ public class EntityJavaMappingClassCreator extends MtpCuiBase {
 			new EntityJavaMappingClassCreator(args).execute();
 		} catch (Exception e) {
 			e.printStackTrace();
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityUpdateAll.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityUpdateAll.java
@@ -56,6 +56,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
@@ -112,6 +113,8 @@ public class EntityUpdateAll extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityViewDDLCreator.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/entity/EntityViewDDLCreator.java
@@ -37,6 +37,7 @@ import org.iplass.mtp.impl.tools.entity.EntityToolService;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -217,6 +218,9 @@ public class EntityViewDDLCreator extends MtpCuiBase {
 			new EntityViewDDLCreator(args).execute();
 		} catch (Exception e) {
 			e.printStackTrace();
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/fulltextsearch/EntityDataCrawler.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/fulltextsearch/EntityDataCrawler.java
@@ -14,6 +14,7 @@ import org.iplass.mtp.impl.core.ExecuteContext;
 import org.iplass.mtp.impl.core.TenantContextService;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.transaction.Transaction;
 import org.slf4j.Logger;
@@ -74,15 +75,20 @@ public class EntityDataCrawler extends MtpSilentBatch {
 					}
 				}
 
-				if (tenantId >= 0) {
-					(new EntityDataCrawler(mode, tenantId, ename)).execute();
-				} else {
-					List<TenantInfo> tenants = getValidTenantInfoList();
-					if (tenants != null) {
-						for (TenantInfo t: tenants) {
-							(new EntityDataCrawler(mode, t.getId(), ename)).execute();
+				try {
+					if (tenantId >= 0) {
+						(new EntityDataCrawler(mode, tenantId, ename)).execute();
+					} else {
+						List<TenantInfo> tenants = getValidTenantInfoList();
+						if (tenants != null) {
+							for (TenantInfo t: tenants) {
+								(new EntityDataCrawler(mode, t.getId(), ename)).execute();
+							}
 						}
 					}
+				} finally {
+					// リソース破棄
+					MtpBatchResourceDisposer.disposeResource();
 				}
 			}
 		}

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/lob/LobStoreMigrator.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/lob/LobStoreMigrator.java
@@ -32,6 +32,7 @@ import org.iplass.mtp.impl.rdb.adapter.RdbAdapter;
 import org.iplass.mtp.impl.rdb.adapter.RdbAdapterService;
 import org.iplass.mtp.impl.tools.tenant.TenantInfo;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpSilentBatch;
 import org.iplass.mtp.transaction.Transaction;
 import org.slf4j.Logger;
@@ -73,15 +74,20 @@ public class LobStoreMigrator extends MtpSilentBatch {
 		String rootDir = args[2];
 		int tenantId = Integer.parseInt(args[3]);
 
-		if (tenantId >= 0) {
-			(new LobStoreMigrator(mode, target, rootDir, tenantId)).execute();
-		} else {
-			List<TenantInfo> tenants = getValidTenantInfoList();
-			if (tenants != null) {
-				for (TenantInfo t: tenants) {
-					(new LobStoreMigrator(mode, target, rootDir, t.getId())).execute();
+		try {
+			if (tenantId >= 0) {
+				(new LobStoreMigrator(mode, target, rootDir, tenantId)).execute();
+			} else {
+				List<TenantInfo> tenants = getValidTenantInfoList();
+				if (tenants != null) {
+					for (TenantInfo t: tenants) {
+						(new LobStoreMigrator(mode, target, rootDir, t.getId())).execute();
+					}
 				}
 			}
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataExport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataExport.java
@@ -45,6 +45,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.pack.PackageExport;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.CollectionUtil;
@@ -83,6 +84,8 @@ public class MetaDataExport extends MtpCuiBase {
 			e.printStackTrace();
 		} finally {
 			ExecuteContext.finContext();
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataImport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataImport.java
@@ -35,6 +35,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.pack.PackageExport;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.CollectionUtil;
@@ -77,6 +78,8 @@ public class MetaDataImport extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataNameListExport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataNameListExport.java
@@ -25,6 +25,7 @@ import org.iplass.mtp.impl.tools.pack.PackageService;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
@@ -56,6 +57,8 @@ public class MetaDataNameListExport extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataPatch.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/metadata/MetaDataPatch.java
@@ -13,6 +13,7 @@ import org.iplass.mtp.impl.tools.metaport.PatchEntityDataParameter;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,6 +97,9 @@ public class MetaDataPatch extends MtpCuiBase {
 			new MetaDataPatch(args).execute();
 		} catch (Exception e) {
 			e.printStackTrace();
+		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageExport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageExport.java
@@ -60,6 +60,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
@@ -102,6 +103,8 @@ public class PackageExport extends MtpCuiBase {
 			e.printStackTrace();
 		} finally {
 			ExecuteContext.finContext();
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageImport.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/pack/PackageImport.java
@@ -57,6 +57,7 @@ import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tenant.Tenant;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.transaction.Transaction;
 import org.iplass.mtp.util.CollectionUtil;
 import org.iplass.mtp.util.StringUtil;
@@ -108,6 +109,8 @@ public class PackageImport extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			// リソース破棄
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/partition/MySQLPartitionBatch.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/partition/MySQLPartitionBatch.java
@@ -28,6 +28,7 @@ import org.iplass.mtp.impl.tools.tenant.PartitionInfo;
 import org.iplass.mtp.impl.tools.tenant.TenantToolService;
 import org.iplass.mtp.impl.tools.tenant.log.LogHandler;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
 import org.iplass.mtp.tools.gui.partition.MySQLPartitionManagerApp;
 import org.iplass.mtp.util.StringUtil;
@@ -58,6 +59,13 @@ public class MySQLPartitionBatch extends MtpCuiBase implements PartitionBatch {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			if (instance.getExecMode() == MySQLPartitionBatchExecMode.GUI) {
+				MtpBatchResourceDisposer.addShutdownHookForDisposeResource(() -> {
+					// NOTE 個別の破棄処理が必要な場合は、ここに実装する。
+				});
+			} else {
+				MtpBatchResourceDisposer.disposeResource();
+			}
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/partition/PostgreSQLPartitionBatch.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/partition/PostgreSQLPartitionBatch.java
@@ -29,6 +29,7 @@ import org.iplass.mtp.impl.tools.tenant.TenantToolService;
 import org.iplass.mtp.impl.tools.tenant.log.LogHandler;
 import org.iplass.mtp.impl.tools.tenant.rdb.TenantRdbConstants;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
 import org.iplass.mtp.tools.gui.partition.MySQLPartitionManagerApp;
 import org.iplass.mtp.util.StringUtil;
@@ -57,6 +58,14 @@ public class PostgreSQLPartitionBatch extends MtpCuiBase implements PartitionBat
 			instance.execute();
 		} catch (Throwable e) {
 			e.printStackTrace();
+		} finally {
+			if (instance.getExecMode() == PostgreSQLPartitionBatchExecMode.GUI) {
+				MtpBatchResourceDisposer.addShutdownHookForDisposeResource(() -> {
+					// NOTE 個別の破棄処理が必要な場合は、ここに実装する。
+				});
+			} else {
+				MtpBatchResourceDisposer.disposeResource();
+			}
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/storagespace/ObjStoreDDLGenerateBatch.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/storagespace/ObjStoreDDLGenerateBatch.java
@@ -30,6 +30,7 @@ import org.iplass.mtp.impl.script.template.GroovyTemplateCompiler;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +95,7 @@ public class ObjStoreDDLGenerateBatch extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/storagespace/StorageSpaceCleaner.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/storagespace/StorageSpaceCleaner.java
@@ -14,6 +14,7 @@ import org.iplass.mtp.impl.tools.storagespace.StorageSpaceService;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.ExecMode;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,8 @@ public class StorageSpaceCleaner extends MtpCuiBase {
 			new StorageSpaceCleaner(args).execute();
 		} catch (Exception e) {
 			e.printStackTrace();
+		} finally {
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/storagespace/StorageSpaceMigration.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/storagespace/StorageSpaceMigration.java
@@ -22,6 +22,7 @@ import org.iplass.mtp.impl.metadata.MetaDataContext;
 import org.iplass.mtp.impl.tools.storagespace.StorageSpaceService;
 import org.iplass.mtp.spi.ServiceRegistry;
 import org.iplass.mtp.tools.batch.ExecMode;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
 import org.iplass.mtp.tools.batch.storagespace.tableallocators.LocationSpecificationTableAllocator;
 import org.iplass.mtp.util.StringUtil;
@@ -111,8 +112,7 @@ public class StorageSpaceMigration extends MtpCuiBase {
 		} catch (Exception e) {
 			e.printStackTrace();
 		} finally {
-			// 全サービス終了
-			ServiceRegistry.getRegistry().destroyAllService();
+			MtpBatchResourceDisposer.disposeResource();
 		}
 	}
 

--- a/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/tenant/TenantBatch.java
+++ b/iplass-tools-batch/src/main/java/org/iplass/mtp/tools/batch/tenant/TenantBatch.java
@@ -39,6 +39,7 @@ import org.iplass.mtp.impl.tools.tenant.TenantToolService;
 import org.iplass.mtp.impl.tools.tenant.log.LogHandler;
 import org.iplass.mtp.impl.tools.tenant.rdb.TenantRdbConstants;
 import org.iplass.mtp.spi.ServiceRegistry;
+import org.iplass.mtp.tools.batch.MtpBatchResourceDisposer;
 import org.iplass.mtp.tools.batch.MtpCuiBase;
 import org.iplass.mtp.tools.gui.tenant.TenantManagerApp;
 import org.iplass.mtp.util.StringUtil;
@@ -76,6 +77,13 @@ public class TenantBatch extends MtpCuiBase {
 		} catch (Throwable e) {
 			e.printStackTrace();
 		} finally {
+			if (instance.getExecMode() == TenantBatchExecMode.GUI) {
+				MtpBatchResourceDisposer.addShutdownHookForDisposeResource(() -> {
+					// NOTE 個別の破棄処理が必要な場合は、ここに実装する。
+				});
+			} else {
+				MtpBatchResourceDisposer.disposeResource();
+			}
 		}
 	}
 

--- a/iplass-web/src/main/java/org/iplass/mtp/command/annotation/action/ActionMapping.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/command/annotation/action/ActionMapping.java
@@ -111,12 +111,23 @@ public @interface ActionMapping {
 	 * publicActionとの違いは、Entity権限など、すべての権限が許可された状態で実行されます。
 	 * 
 	 * @return
+	 * @deprecated {@link #privileged()} を使用してください。
 	 */
+	@Deprecated
 	boolean privilaged() default false;
+	
+	/**
+	 * このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうかを設定します。
+	 * デフォルトはfalseです。
+	 * publicActionとの違いは、Entity権限など、すべての権限が許可された状態で実行されます。
+	 * 
+	 * @return
+	 */
+	boolean privileged() default false;
 
 	/**
 	 * このActionの呼び出しをAction権限設定によらず呼び出し可能にする場合は、trueを設定します。
-	 * isPrivilagedとの違いは、Entityの操作などAction権限以外の権限がチェックされる状況においては、
+	 * isPrivilegedとの違いは、Entityの操作などAction権限以外の権限がチェックされる状況においては、
 	 * セキュリティ制約を受けます。
 	 * デフォルトはfalseです。
 	 * 

--- a/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
@@ -69,12 +69,18 @@ public @interface WebApi {
 	long cacheControlMaxAge() default -1;
 
 	boolean checkXRequestedWithHeader() default true;
+	/** @deprecated {@link #privileged()} を使用してください。 */
+	@Deprecated
 	boolean privilaged() default false;
+	boolean privileged() default false;
 	boolean publicWebApi() default false;
 	boolean overwritable() default true;
 	boolean permissionSharable() default false;
 
+	/** @deprecated {@link #accessControlAllowOrigin()} を使用してください。 */
+	@Deprecated
 	String accessControlAllowOrign() default "";
+	String accessControlAllowOrigin() default "";
 	boolean accessControlAllowCredentials() default false;
 	boolean needTrustedAuthenticate() default false;
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/oidc/command/AuthCallbackCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/oidc/command/AuthCallbackCommand.java
@@ -40,7 +40,7 @@ import org.iplass.mtp.web.WebRequestConstants;
 @ActionMapping(name=AuthCallbackCommand.ACTION_NAME,
 	clientCacheType=ClientCacheType.NO_CACHE,
 	publicAction=true,
-	privilaged=true,
+	privileged=true,
 	paramMapping={
 			@ParamMapping(name=AuthCallbackCommand.PARAM_DEFINITION_NAME, mapFrom=ParamMapping.PATHS)
 	},

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/IntrospectCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/IntrospectCommand.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 	accepts=RequestType.REST_FORM,
 	methods=MethodType.POST,
 	checkXRequestedWithHeader=false,
-	privilaged=true,
+	privileged=true,
 	state=StateType.STATELESS,
 	responseType="application/json"
 )

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/RevokeCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/RevokeCommand.java
@@ -34,7 +34,7 @@ import org.iplass.mtp.webapi.definition.StateType;
 	accepts=RequestType.REST_FORM,
 	methods=MethodType.POST,
 	checkXRequestedWithHeader=false,
-	privilaged=true,
+	privileged=true,
 	state=StateType.STATELESS,
 	responseType="application/json"
 )

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/TokenCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/TokenCommand.java
@@ -50,7 +50,7 @@ import org.iplass.mtp.webapi.definition.StateType;
 	accepts=RequestType.REST_FORM,
 	methods=MethodType.POST,
 	checkXRequestedWithHeader=false,
-	privilaged=true,
+	privileged=true,
 	state=StateType.STATELESS,
 	cacheControlType=CacheControlType.NO_CACHE,
 	responseType="application/json"

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMapping.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMapping.java
@@ -99,9 +99,9 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 	private boolean isParts;
 
 	/** このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged = false;
+	private boolean isPrivileged = false;
 
-	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicAction;
 
 	/** このActionMappingが呼び出されたときに実行するCommand。未指定可（Commandは実行せずテンプレートを表示）。 */
@@ -221,12 +221,24 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		this.isPublicAction = isPublicAction;
 	}
 
+	/** @deprecated {@link #isPrivileged()} を使用してください。 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	/** @deprecated {@link #setPrivileged(boolean)} を使用してください。 */
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 	public ParamMap[] getParamMap() {
@@ -299,7 +311,13 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		clientCacheMaxAge = definition.getClientCacheMaxAge();
 
 		isParts = definition.isParts();
-		isPrivilaged = definition.isPrivilaged();
+		
+		if (definition.isPrivileged()) {
+			isPrivileged = definition.isPrivileged();
+		} else {
+			isPrivileged = definition.isPrivilaged();
+		}
+		
 		isPublicAction = definition.isPublicAction();
 
 		if (definition.getCommandConfig() != null) {
@@ -383,7 +401,8 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		definition.setClientCacheType(clientCacheType);
 		definition.setClientCacheMaxAge(clientCacheMaxAge);
 		definition.setParts(isParts);
-		definition.setPrivilaged(isPrivilaged);
+		definition.setPrivilaged(isPrivileged);
+		definition.setPrivileged(isPrivileged);
 		definition.setPublicAction(isPublicAction);
 
 		if (command != null) {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMappingFactory.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMappingFactory.java
@@ -304,7 +304,12 @@ public class MetaActionMappingFactory implements
 		
 		metaActionMapping.setNeedTrustedAuthenticate(actionMapping.needTrustedAuthenticate());
 		metaActionMapping.setParts(actionMapping.parts());
-		metaActionMapping.setPrivilaged(actionMapping.privilaged());
+		metaActionMapping.setPrivileged(actionMapping.privileged());
+		if (actionMapping.privileged()) {
+			metaActionMapping.setPrivilaged(actionMapping.privileged());
+		} else {
+			metaActionMapping.setPrivilaged(actionMapping.privilaged());
+		}
 		metaActionMapping.setPublicAction(actionMapping.publicAction());
 
 		if (actionMapping.paramMapping().length > 0) {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/interceptors/AuthInterceptor.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/interceptors/AuthInterceptor.java
@@ -101,9 +101,14 @@ public class AuthInterceptor implements RequestInterceptor,ServiceInitListener<A
 	public void destroyed() {
 	}
 	private AuthContextHolder getAuthContextHolder(ActionMappingRuntime action) {
-		if (action.getMetaData().isPrivilaged()) {
+		if (action.getMetaData().isPrivileged()) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("do as privilaged action:" + action.getMetaData().getName());
+				logger.debug("do as Privileged action:" + action.getMetaData().getName());
+			}
+			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
+		} else if (action.getMetaData().isPrivilaged()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("do as Privilaged action:" + action.getMetaData().getName());
 			}
 			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
 		} else {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApi.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApi.java
@@ -109,9 +109,9 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 	private String restXmlParameterName = null;
 
 	/** このWebAPIで処理されるCommandを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged = false;
+	private boolean isPrivileged = false;
 
-	/** このWebAPIの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このWebAPIの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicWebApi;
 
 	/** Tokenチェックの実行設定。未指定可(Tokenチェックは実行されない)。 */
@@ -249,12 +249,24 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 		this.tokenCheck = tokenCheck;
 	}
 
+	/** @deprecated {@link #isPrivileged()} を使用してください。 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	/** @deprecated {@link #setPrivileged(boolean)} を使用してください。 */
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 	public boolean isPublicWebApi() {
@@ -794,7 +806,8 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 		definition.setCacheControlType(cacheControlType);
 		definition.setCacheControlMaxAge(cacheControlMaxAge);
 
-		definition.setPrivilaged(isPrivilaged);
+		definition.setPrivilaged(isPrivileged);
+		definition.setPrivileged(isPrivileged);
 		definition.setPublicWebApi(isPublicWebApi);
 		definition.setCheckXRequestedWithHeader(isCheckXRequestedWithHeader);
 
@@ -848,7 +861,13 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 			results = null;
 		}
 
-		isPrivilaged = definition.isPrivilaged();
+		if (definition.isPrivileged()) 
+		{
+			isPrivileged = definition.isPrivileged();
+		} else {
+			isPrivileged = definition.isPrivilaged();
+		}
+		
 		isPublicWebApi = definition.isPublicWebApi();
 		isCheckXRequestedWithHeader = definition.isCheckXRequestedWithHeader();
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
@@ -30,6 +30,7 @@ import org.iplass.mtp.impl.command.MetaCommand;
 import org.iplass.mtp.impl.command.MetaCommandFactory;
 import org.iplass.mtp.impl.metadata.annotation.AnnotatableMetaDataFactory;
 import org.iplass.mtp.impl.metadata.annotation.AnnotateMetaDataEntry;
+import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.webapi.definition.CacheControlType;
 
 
@@ -145,7 +146,12 @@ public class MetaWebApiFactory implements AnnotatableMetaDataFactory<WebApi, Obj
 		if (webapi.oauthScopes() != null && webapi.oauthScopes().length > 0) {
 			meta.setOauthScopes(webapi.oauthScopes());
 		}
-		meta.setPrivilaged(webapi.privilaged());
+		meta.setPrivileged(webapi.privileged());
+		if (webapi.privileged()) {
+			meta.setPrivilaged(webapi.privileged());
+		} else {
+			meta.setPrivilaged(webapi.privilaged());
+		}
 		meta.setPublicWebApi(webapi.publicWebApi());
 		meta.setCheckXRequestedWithHeader(webapi.checkXRequestedWithHeader());
 		meta.setResponseType(webapi.responseType());
@@ -172,7 +178,11 @@ public class MetaWebApiFactory implements AnnotatableMetaDataFactory<WebApi, Obj
 		}
 
 		meta.setSynchronizeOnSession(webapi.synchronizeOnSession());
-		meta.setAccessControlAllowOrigin(webapi.accessControlAllowOrign());
+		if (StringUtil.isNotBlank(webapi.accessControlAllowOrigin())) {
+			meta.setAccessControlAllowOrigin(webapi.accessControlAllowOrigin());
+		} else {
+			meta.setAccessControlAllowOrigin(webapi.accessControlAllowOrign());
+		}
 		meta.setAccessControlAllowCredentials(webapi.accessControlAllowCredentials());
 		meta.setNeedTrustedAuthenticate(webapi.needTrustedAuthenticate());
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/interceptors/AuthInterceptor.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/interceptors/AuthInterceptor.java
@@ -63,9 +63,14 @@ public class AuthInterceptor implements CommandInterceptor {
 	private SessionService sessionService = ServiceRegistry.getRegistry().getService(SessionService.class);
 
 	private AuthContextHolder getAuthContextHolder(WebApiRuntime webapi) {
-		if (webapi.getMetaData().isPrivilaged()) {
+		if (webapi.getMetaData().isPrivileged()) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("do as privilaged webapi:" + webapi.getMetaData().getName());
+				logger.debug("do as Privileged webapi:" + webapi.getMetaData().getName());
+			}
+			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
+		} else if (webapi.getMetaData().isPrivilaged()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("do as Privilaged webapi:" + webapi.getMetaData().getName());
 			}
 			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
 		} else {

--- a/iplass-web/src/main/java/org/iplass/mtp/web/actionmapping/definition/ActionMappingDefinition.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/web/actionmapping/definition/ActionMappingDefinition.java
@@ -67,9 +67,9 @@ public class ActionMappingDefinition implements Definition {
 	private boolean isParts;
 
 	/** このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged;
+	private boolean isPrivileged;
 	
-	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicAction;
 
 	/**
@@ -195,7 +195,7 @@ public class ActionMappingDefinition implements Definition {
 
 	/**
 	 * このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。
-	 * isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。
+	 * isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。
 	 * デフォルトはfalse。
 	 * 
 	 * @param isPublicAction
@@ -348,19 +348,41 @@ public class ActionMappingDefinition implements Definition {
 	/**
 	 * @see #setPrivilaged(boolean)
 	 * @return
+	 * @deprecated {@link #isPrivileged()} を使用してください。
 	 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
 	/**
 	 * このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうかを設定。
 	 * デフォルトはfalse。
 	 *
-	 * @param isPrivilaged
+	 * @param isPrivileged
+	 * @deprecated {@link #setPrivileged(boolean)} を使用してください。 
 	 */
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	/**
+	 * @see #setPrivileged(boolean)
+	 * @return
+	 */
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	/**
+	 * このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうかを設定。
+	 * デフォルトはfalse。
+	 *
+	 * @param isPrivileged
+	 */
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 

--- a/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/WebApiDefinition.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/WebApiDefinition.java
@@ -55,9 +55,9 @@ public class WebApiDefinition implements Definition {
 	private WebApiParamMapDefinition[] webApiParamMap;
 
 	/** このWebApiで処理されるCommandを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged;
+	private boolean isPrivileged;
 
-	/** このWebApiの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このWebApiの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicWebApi;
 
 	/** XMLHttpRequestがセットされていることを確認するか。 */
@@ -420,7 +420,7 @@ public class WebApiDefinition implements Definition {
 
 	/**
 	 * このWebApiの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定します。
-	 * isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受けます。
+	 * isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受けます。
 	 * デフォルトはfalseです。
 	 *
 	 * @param isPublicWebApi
@@ -432,17 +432,37 @@ public class WebApiDefinition implements Definition {
 	/**
 	 *
 	 * @return
+	 * @deprecated {@link #isPrivileged()} を使用してください。
 	 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
 	/**
 	 *
-	 * @param isPrivilaged
+	 * @param isPrivileged
+	 * @deprecated {@link #setPrivileged(boolean)} を使用してください。 
 	 */
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	/**
+	 *
+	 * @param isPrivileged
+	 */
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 	/**


### PR DESCRIPTION
WebApiとActionMappingのアノテーションのタイプミスを修正する。
・間違ったスペル「privilaged」を「privileged」に修正する。
　間違ったスペルのモノはdeprecatedにして、残したままの状態にし、正しいスペルのモノを新たに追加する。
・間違ったスペル「accessControlAllowOrign」を「accessControlAllowOrigin」に修正する。