### PR TITLE
全文検索、Entity定義横断でoidのリストのみを返却するメソッド提供（3.1）

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/service/AdminEntityManager.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/server/base/service/AdminEntityManager.java
@@ -318,6 +318,11 @@ public class AdminEntityManager implements EntityManager {
 	}
 
 	@Override
+	public Map<String, List<String>> fulltextSearchOidList(List<String> definitionNames, String keyword) {
+		return em.fulltextSearchOidList(definitionNames, keyword);
+	}
+
+	@Override
 	public <T extends Entity> SearchResult<T> fulltextSearchEntity(Query query, String keyword, SearchOption option) {
 		return em.fulltextSearchEntity(query, keyword, option);
 	}

--- a/iplass-core/src/main/java/org/iplass/mtp/entity/EntityManager.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/entity/EntityManager.java
@@ -510,6 +510,16 @@ public interface EntityManager extends Manager {
 	public List<String> fulltextSearchOidList(String definitionName, String keyword);
 
 	/**
+	 * 指定のワードで全文検索し、対象Entity毎のoidリストのMapを取得します。
+	 * definitionNames、keywordは必須。未指定の場合は空のMapを返却します。
+	 *
+	 * @param definitionNames Entity定義名のリスト
+	 * @param keyword 全文検索用キーワード
+	 * @return 検索キーワードを含むエンティティデータのoidリストのMap
+	 */
+	public Map<String, List<String>> fulltextSearchOidList(List<String> definitionNames, String keyword);
+
+	/**
 	 * 指定のワードで全文検索し、指定プロパティのみを取得します。
 	 * entityPropertiesが未指定の場合は利用テナントの全エンティティに対して全文検索を実施します。
 	 *

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/entity/EntityManagerImpl.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/entity/EntityManagerImpl.java
@@ -1537,6 +1537,11 @@ public class EntityManagerImpl implements EntityManager {
 	}
 
 	@Override
+	public Map<String, List<String>> fulltextSearchOidList(List<String> defNames, String fulltext) {
+		return fulltextSearchService.fulltextSearchOidList(defNames, fulltext);
+	}
+
+	@Override
 	public <T extends Entity> SearchResult<T> fulltextSearchEntity(Map<String, List<String>> entityProperties,
 			String fulltext) {
 		return fulltextSearchService.fulltextSearchEntity(entityProperties, fulltext);

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchLuceneService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchLuceneService.java
@@ -786,6 +786,13 @@ public class FulltextSearchLuceneService extends AbstractFulltextSeachService {
 		}
 	}
 
+	@Deprecated
+	@Override
+	public Map<String, List<String>> fulltextSearchOidList(List<String> searchDefNames, String fulltext) {
+		//未実装
+		throw new UnsupportedOperationException("Method is unavailable.");
+	}
+
 	@Override
 	public List<FulltextSearchResult> execFulltextSearch(String searchDefName, String keywords) {
 		if (searcherManager == null) {

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/FulltextSearchService.java
@@ -124,6 +124,15 @@ public interface FulltextSearchService extends Service {
 	 */
 	List<String> fulltextSearchOidList(String defName, String keyword);
 
+	/**
+	 * 全文検索を実行し、対象Entity毎の検索結果OIDリストのMapを返す。 
+	 *
+	 * @param defNames Entity定義名のリスト
+	 * @param keyword キーワード
+	 * @return 対象Entity毎の検索結果OIDリストのMap
+	 */
+	Map<String, List<String>> fulltextSearchOidList(List<String> defNames, String keyword);
+
 
 	//TODO 現状Luceneの場合、FulltextSearchResultはoidのみ
 	/**

--- a/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/lucene/LuceneFulltextSearchService.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/impl/fulltextsearch/lucene/LuceneFulltextSearchService.java
@@ -845,6 +845,27 @@ public class LuceneFulltextSearchService extends AbstractFulltextSeachService {
 	}
 
 	@Override
+	public Map<String, List<String>> fulltextSearchOidList(List<String> searchDefNames, String fulltext) {
+		Map<String, List<String>> resMap = new HashMap<>();
+		EntityContext ec = EntityContext.getCurrentContext();
+		List<IndexedEntity> fromIndexList = Collections.emptyList();
+
+		for (String searchDefName: searchDefNames) {
+			resMap.put(searchDefName, new ArrayList<String>());
+			EntityHandler eh = ec.getHandlerByName(searchDefName);
+			List<IndexedEntity> iel = fulltextSearchImpl(ec.getTenantId(eh), eh, fulltext, getMaxRows());
+			fromIndexList = mergeSortByScore(fromIndexList, iel, getMaxRows(), t -> t.score);
+		}
+
+		for (IndexedEntity ie: fromIndexList) {
+			List<String> oidList = resMap.get(ie.defName);
+			oidList.add(ie.oid);
+		}
+		
+		return resMap;
+	}
+
+	@Override
 	public List<FulltextSearchResult> execFulltextSearch(String searchDefName, String keywords) {
 		EntityContext ec = EntityContext.getCurrentContext();
 		EntityHandler eh = ec.getHandlerByName(searchDefName);


### PR DESCRIPTION
現状、単一のEntity定義に対して、全文検索エンジンのみをクエリしてoidのリストを返却するメソッドは存在するが、 Entity定義横断で全文検索エンジンのみをクエリしてoidのリストを返却するメソッドがないのでそれを追加する。
複数Entity全部のoidのトータル件数が定数maxRowsを超えないようにスコア降順で上位のものを取得する。