### PR TITLE
gem、NestTableにて参照コンボを動作可能にする

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/MetaDataRefs.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/MetaDataRefs.java
@@ -69,6 +69,7 @@ import org.iplass.gem.command.generic.detail.UpdateMappedbyReferenceCommand;
 import org.iplass.gem.command.generic.detail.UpdateReferencePropertyCommand;
 import org.iplass.gem.command.generic.detail.UpdateTableOrderCommand;
 import org.iplass.gem.command.generic.refcombo.GetEditorCommand;
+import org.iplass.gem.command.generic.refcombo.GetReferenceComboSettingCommand;
 import org.iplass.gem.command.generic.refcombo.ReferenceComboCommand;
 import org.iplass.gem.command.generic.refcombo.SearchParentCommand;
 import org.iplass.gem.command.generic.reflink.GetReferenceLinkItemCommand;
@@ -146,6 +147,7 @@ import org.iplass.mtp.command.annotation.MetaDataSeeAlso;
 	//自動補完
 	GetAutocompletionValueCommand.class,
 	//参照コンボ
+	GetReferenceComboSettingCommand.class,
 	GetEditorCommand.class,
 	ReferenceComboCommand.class,
 	SearchParentCommand.class,

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/GetEditorCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/GetEditorCommand.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2013 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -32,9 +32,12 @@ import org.iplass.mtp.entity.Entity;
 import org.iplass.mtp.view.generic.EntityViewManager;
 import org.iplass.mtp.view.generic.editor.PropertyEditor;
 import org.iplass.mtp.view.generic.editor.ReferencePropertyEditor;
-import org.iplass.mtp.webapi.definition.RequestType;
 import org.iplass.mtp.webapi.definition.MethodType;
+import org.iplass.mtp.webapi.definition.RequestType;
 
+/**
+ * @deprecated use {@link GetReferenceComboSettingCommand}
+ */
 @WebApi(
 		name=GetEditorCommand.WEBAPI_NAME,
 		accepts=RequestType.REST_JSON,
@@ -43,7 +46,8 @@ import org.iplass.mtp.webapi.definition.MethodType;
 		results={"editor"},
 		checkXRequestedWithHeader=true
 	)
-@CommandClass(name="gem/generic/refcombo/GetEditorCommand", displayName="プロパティエディタ取得マンド")
+@CommandClass(name="gem/generic/refcombo/GetEditorCommand", displayName="プロパティエディタ取得")
+@Deprecated
 public final class GetEditorCommand implements Command, HasDisplayScriptBindings{
 
 	public static final String CMD_NAME = "gem/generic/refcombo/GetEditorCommand";

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/GetReferenceComboSettingCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/GetReferenceComboSettingCommand.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.gem.command.generic.refcombo;
+
+import org.iplass.gem.command.Constants;
+import org.iplass.gem.command.generic.HasDisplayScriptBindings;
+import org.iplass.mtp.ManagerLocator;
+import org.iplass.mtp.command.Command;
+import org.iplass.mtp.command.RequestContext;
+import org.iplass.mtp.command.annotation.CommandClass;
+import org.iplass.mtp.command.annotation.webapi.RestJson;
+import org.iplass.mtp.command.annotation.webapi.WebApi;
+import org.iplass.mtp.entity.Entity;
+import org.iplass.mtp.view.generic.EntityViewManager;
+import org.iplass.mtp.view.generic.editor.PropertyEditor;
+import org.iplass.mtp.view.generic.editor.ReferencePropertyEditor;
+import org.iplass.mtp.webapi.definition.MethodType;
+import org.iplass.mtp.webapi.definition.RequestType;
+
+/**
+ * 参照コンボ設定取得処理
+ */
+@WebApi(
+		name=GetReferenceComboSettingCommand.WEBAPI_NAME,
+		accepts=RequestType.REST_JSON,
+		methods=MethodType.POST,
+		restJson=@RestJson(parameterName="param"),
+		results={GetReferenceComboSettingCommand.RESULT_DATA_NAME},
+		checkXRequestedWithHeader=true
+	)
+@CommandClass(name=GetReferenceComboSettingCommand.CMD_NAME, displayName="参照コンボ設定取得")
+public class GetReferenceComboSettingCommand implements Command, HasDisplayScriptBindings{
+
+	public static final String CMD_NAME = "gem/generic/refcombo/GetReferenceComboSettingCommand";
+	public static final String WEBAPI_NAME = "gem/generic/refcombo/getComboSetting";
+
+	/** 返却値のKEY名 */
+	public static final String RESULT_DATA_NAME = "setting";
+
+	private EntityViewManager evm = null;
+
+	public GetReferenceComboSettingCommand() {
+		evm = ManagerLocator.getInstance().getManager(EntityViewManager.class);
+	}
+
+	@Override
+	public String execute(RequestContext request) {
+		String defName = request.getParam(Constants.DEF_NAME);
+		String viewName = request.getParam(Constants.VIEW_NAME);
+		String propName = request.getParam(Constants.PROP_NAME);
+		String viewType = request.getParam(Constants.VIEW_TYPE);
+
+		Entity entity = getBindingEntity(request);
+		//Editor取得
+		PropertyEditor editor = evm.getPropertyEditor(defName, viewType, viewName, propName, entity);
+		ReferencePropertyEditor rpe = null;
+		if (editor instanceof ReferencePropertyEditor) {
+			rpe = (ReferencePropertyEditor)editor;
+		}
+		if (rpe == null) {
+			return "NOT_DEFINED_EDITOR";
+		}
+
+		request.setAttribute(RESULT_DATA_NAME, rpe.getReferenceComboSetting());
+		return Constants.CMD_EXEC_SUCCESS;
+	}
+
+}

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/ReferenceComboCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/ReferenceComboCommand.java
@@ -103,6 +103,10 @@ public final class ReferenceComboCommand implements Command, HasDisplayScriptBin
 		}
 
 		if (rpe != null) {
+			// NestTableの場合、Editorのプロパティ名は、参照先の名前になっているので
+			// NestTableも考慮してフルパスにする
+			rpe.setPropertyName(propName);
+
 			Map<String, List<SimpleEntity>> map = getData(rpe, request);
 
 			//map内は1件のはず
@@ -267,7 +271,7 @@ public final class ReferenceComboCommand implements Command, HasDisplayScriptBin
 			}
 		} else {
 			//選択済みの場合は下位のコンボの条件にする
-			conditions.add(new Equals(propName + ".oid", val));
+			conditions.add(new Equals(propName + "." + Entity.OID, val));
 		}
 
 		return conditions;

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/ReferenceComboData.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/refcombo/ReferenceComboData.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2023 INFORMATION SERVICES INTERNATIONAL - DENTSU, LTD. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.gem.command.generic.refcombo;
+
+import java.util.List;
+
+import org.iplass.mtp.entity.Entity;
+import org.iplass.mtp.view.generic.editor.ReferencePropertyEditor.RefSortType;
+
+/**
+ * 連動コンボの選択値
+ */
+public class ReferenceComboData {
+
+	/** プロパティPath */
+	private String propertyPath;
+
+	/** Entity名 */
+	private String entityName;
+
+	/** 上位プロパティ名 */
+	private String parentPropertyName;
+
+	/** 検索条件 */
+	private String condition;
+
+	/** 表示ラベルとして扱うプロパティ */
+	private String displayLabelItem;
+
+	/** ソートプロパティ */
+	private String sortItem;
+
+	/** ソート種別 */
+	private RefSortType sortType;
+
+	/** 現在値 */
+	private String currentValue;
+
+	/** 選択値 */
+	private List<Entity> optionValues;
+
+	/**
+	 * プロパティPathを初期化します。
+	 *
+	 * @param propertyPath プロパティPath
+	 */
+	public ReferenceComboData(String propertyPath) {
+		setPropertyPath(propertyPath);
+	}
+
+	/**
+	 * プロパティPathを返します。
+	 *
+	 * @return プロパティPath
+	 */
+	public String getPropertyPath() {
+		return propertyPath;
+	}
+
+	/**
+	 * プロパティPathを設定します。
+	 *
+	 * @param propertyPath プロパティPath
+	 */
+	public void setPropertyPath(String propertyPath) {
+		this.propertyPath = propertyPath;
+	}
+
+	/**
+	 * Entity名を返します。
+	 *
+	 * @return Entity名
+	 */
+	public String getEntityName() {
+		return entityName;
+	}
+
+	/**
+	 * Entity名を設定します。
+	 *
+	 * @param entityName Entity名
+	 */
+	public void setEntityName(String entityName) {
+		this.entityName = entityName;
+	}
+
+	/**
+	 * 上位プロパティ名を返します。
+	 *
+	 * @return 上位プロパティ名
+	 */
+	public String getParentPropertyName() {
+		return parentPropertyName;
+	}
+
+	/**
+	 * 上位プロパティ名を設定します。
+	 *
+	 * @param parentPropertyName 上位プロパティ名
+	 */
+	public void setParentPropertyName(String parentPropertyName) {
+		this.parentPropertyName = parentPropertyName;
+	}
+
+	/**
+	 * 検索条件を返します。
+	 *
+	 * @return 検索条件
+	 */
+	public String getCondition() {
+		return condition;
+	}
+
+	/**
+	 * 検索条件を設定します。
+	 *
+	 * @param condition 検索条件
+	 */
+	public void setCondition(String condition) {
+		this.condition = condition;
+	}
+
+	/**
+	 * 表示ラベルとして扱うプロパティを返します。
+	 *
+	 * @return 表示ラベルとして扱うプロパティ
+	 */
+	public String getDisplayLabelItem() {
+		return displayLabelItem;
+	}
+
+	/**
+	 * 表示ラベルとして扱うプロパティを設定します。
+	 *
+	 * @param displayLabelItem 表示ラベルとして扱うプロパティ
+	 */
+	public void setDisplayLabelItem(String displayLabelItem) {
+		this.displayLabelItem = displayLabelItem;
+	}
+
+	/**
+	 * ソートプロパティを返します。
+	 *
+	 * @return ソートプロパティ
+	 */
+	public String getSortItem() {
+		return sortItem;
+	}
+
+	/**
+	 * ソートプロパティを設定します。
+	 *
+	 * @param sortItem ソートプロパティ
+	 */
+	public void setSortItem(String sortItem) {
+		this.sortItem = sortItem;
+	}
+
+	/**
+	 * ソート種別を返します。
+	 *
+	 * @return ソート種別
+	 */
+	public RefSortType getSortType() {
+		return sortType;
+	}
+
+	/**
+	 * ソート種別を設定します。
+	 *
+	 * @param sortType ソート種別
+	 */
+	public void setSortType(RefSortType sortType) {
+		this.sortType = sortType;
+	}
+
+	/**
+	 * 現在値を返します。
+	 *
+	 * @return 現在値
+	 */
+	public String getCurrentValue() {
+		return currentValue;
+	}
+
+	/**
+	 * 現在値を設定します。
+	 *
+	 * @param currentValue 現在値
+	 */
+	public void setCurrentValue(String currentValue) {
+		this.currentValue = currentValue;
+	}
+
+	/**
+	 * 選択値を返します。
+	 *
+	 * @return 選択値
+	 */
+	public List<Entity> getOptionValues() {
+		return optionValues;
+	}
+
+	/**
+	 * 選択値を設定します。
+	 *
+	 * @param optionValues 選択値
+	 */
+	public void setOptionValues(List<Entity> optionValues) {
+		this.optionValues = optionValues;
+	}
+
+}

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Condition.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Condition.jsp
@@ -51,8 +51,8 @@
 <%@ page import="org.iplass.mtp.ManagerLocator" %>
 <%@ page import="org.iplass.mtp.impl.util.ConvertUtil" %>
 <%@ page import="org.iplass.gem.command.generic.detail.DetailViewCommand"%>
+<%@ page import="org.iplass.gem.command.generic.refcombo.GetReferenceComboSettingCommand"%>
 <%@ page import="org.iplass.gem.command.generic.reflink.GetReferenceLinkItemCommand"%>
-<%@ page import="org.iplass.gem.command.generic.refcombo.GetEditorCommand"%>
 <%@ page import="org.iplass.gem.command.generic.refcombo.ReferenceComboCommand"%>
 <%@ page import="org.iplass.gem.command.generic.refcombo.SearchParentCommand"%>
 <%@ page import="org.iplass.gem.command.generic.reftree.SearchTreeDataCommand"%>
@@ -599,7 +599,7 @@ $(function() {
  data-searchType="<%=searchType%>"
  data-prefix="sc_"
  data-webapiName="<%=ReferenceComboCommand.WEBAPI_NAME%>"
- data-getEditorWebapiName="<%=GetEditorCommand.WEBAPI_NAME %>"
+ data-getComboSettingWebapiName="<%=GetReferenceComboSettingCommand.WEBAPI_NAME %>"
  data-searchParentWebapiName="<%=SearchParentCommand.WEBAPI_NAME %>"
  data-oid="<c:out value="<%=currentOid%>"/>"
  data-upperName="<c:out value="<%=upperName%>" />"

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
@@ -1460,7 +1460,7 @@ function <%=toggleAddBtnFunc%>() {
 
 	} else if (editor.getDisplayType() == ReferenceDisplayType.REFCOMBO && updatable && !isMappedby) {
 		//連動コンボ
-		//多重度1限定
+		//多重度1限定 //FIXME 多重度複数のロジックもあるが限定か？
 %>
 <jsp:include page="ReferencePropertyEditor_RefCombo.jsp" />
 <%

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_RefCombo.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_RefCombo.jsp
@@ -22,20 +22,234 @@
 <%@ taglib prefix="m" uri="http://iplass.org/tags/mtp"%>
 <%@ page language="java" contentType="text/html; charset=utf-8" pageEncoding="utf-8" trimDirectiveWhitespaces="true"%>
 
+<%@page import="java.util.ArrayList"%>
+<%@page import="java.util.Collections"%>
+<%@page import="java.util.List"%>
+
+<%@ page import="org.iplass.gem.command.Constants" %>
+<%@ page import="org.iplass.gem.command.GemResourceBundleUtil"%>
+<%@ page import="org.iplass.gem.command.ViewUtil"%>
+<%@ page import="org.iplass.gem.command.generic.refcombo.GetReferenceComboSettingCommand"%>
+<%@ page import="org.iplass.gem.command.generic.refcombo.ReferenceComboCommand"%>
+<%@ page import="org.iplass.gem.command.generic.refcombo.ReferenceComboData"%>
+<%@ page import="org.iplass.gem.command.generic.refcombo.SearchParentCommand"%>
+<%@ page import="org.iplass.mtp.ManagerLocator"%>
 <%@ page import="org.iplass.mtp.entity.Entity" %>
+<%@ page import="org.iplass.mtp.entity.EntityManager"%>
+<%@ page import="org.iplass.mtp.entity.definition.EntityDefinition"%>
+<%@ page import="org.iplass.mtp.entity.definition.EntityDefinitionManager"%>
 <%@ page import="org.iplass.mtp.entity.definition.properties.ReferenceProperty"%>
+<%@ page import="org.iplass.mtp.entity.query.Query"%>
+<%@ page import="org.iplass.mtp.entity.query.PreparedQuery"%>
+<%@ page import="org.iplass.mtp.entity.query.SortSpec"%>
+<%@ page import="org.iplass.mtp.entity.query.SortSpec.SortType"%>
+<%@ page import="org.iplass.mtp.entity.query.condition.Condition"%>
+<%@ page import="org.iplass.mtp.entity.query.condition.expr.And"%>
+<%@ page import="org.iplass.mtp.entity.query.condition.predicate.Equals"%>
 <%@ page import="org.iplass.mtp.util.StringUtil" %>
 <%@ page import="org.iplass.mtp.view.generic.EntityViewUtil"%>
 <%@ page import="org.iplass.mtp.view.generic.editor.*" %>
+<%@ page import="org.iplass.mtp.view.generic.editor.ReferencePropertyEditor.RefSortType"%>
 <%@ page import="org.iplass.mtp.web.template.TemplateUtil" %>
-<%@ page import="org.iplass.gem.command.Constants" %>
-<%@ page import="org.iplass.gem.command.generic.refcombo.GetEditorCommand"%>
-<%@ page import="org.iplass.gem.command.generic.refcombo.ReferenceComboCommand"%>
-<%@ page import="org.iplass.gem.command.generic.refcombo.SearchParentCommand"%>
 
+<%!
+	private EntityDefinitionManager edm =  ManagerLocator.manager(EntityDefinitionManager.class);
+	private EntityManager em = ManagerLocator.manager(EntityManager.class);
+
+	/**
+	 * コンボ情報の取得
+	 *
+	 * コンボ設定を解析して、表示コンボとその選択肢を取得します。
+	 *
+	 * @param editor ReferencePropertyEditor
+	 * @param referenceProperty 参照プロパティ定義
+	 * @param propertyName プロパティ名(フルパス)
+	 * @param currentValue 最下層の選択値
+	 * @return コンボ情報
+	 */
+	List<ReferenceComboData> getComboList(ReferencePropertyEditor editor, ReferenceProperty referenceProperty, 
+			String propertyName, String currentValue) {
+
+		List<ReferenceComboData> comboList = new ArrayList<>();
+		
+		if (editor.getReferenceComboSetting() == null) {
+			return comboList;
+		}
+		ReferenceComboSetting setting = editor.getReferenceComboSetting();
+		
+		// 上位階層のデータ作成
+		initParent(comboList, setting, referenceProperty, propertyName, currentValue);
+
+		// 最下位層のデータ作成
+		ReferenceComboData comboData = new ReferenceComboData(propertyName);
+		comboData.setEntityName(referenceProperty.getObjectDefinitionName());
+		comboData.setParentPropertyName(setting.getPropertyName());
+		comboData.setCondition(editor.getCondition());
+		comboData.setDisplayLabelItem(editor.getDisplayLabelItem());
+		comboData.setSortItem(editor.getSortItem());
+		comboData.setSortType(editor.getSortType());
+		comboData.setCurrentValue(currentValue);
+		comboList.add(comboData);
+
+		// 選択値の取得
+		for (int i = 0; i < comboList.size(); i++) {
+			if (i == 0) {
+				// 先頭
+				searchOptionValues(comboList.get(i), null);
+			} else if (StringUtil.isNotEmpty(comboList.get(i - 1).getCurrentValue())) {
+				// 上位が選択されている場合
+				searchOptionValues(comboList.get(i), comboList.get(i - 1).getCurrentValue());
+			} else {
+				// 選択値なし
+				comboList.get(i).setOptionValues(Collections.emptyList());
+			}
+		}
+			
+		return comboList;
+	}
+
+	/**
+	 * 上位階層データの取得
+	 *
+	 * 上位階層のコンボ生成のための情報を取得します。
+	 *
+	 * @param comboList コンボデータのリスト
+	 * @param setting 連動コンボ設定
+	 * @param currentProperty 子階層の参照プロパティ定義
+	 * @param currentPath 子階層までのパス
+	 * @param childOid 子階層の選択OID
+	 */
+	void initParent(List<ReferenceComboData> comboList, ReferenceComboSetting setting, 
+			ReferenceProperty currentProperty, String currentPath, String childOid) {
+		EntityDefinition currentEntityDefinition = edm.get(currentProperty.getObjectDefinitionName());
+		ReferenceProperty parentProperty = (ReferenceProperty) currentEntityDefinition.getProperty(setting.getPropertyName());
+
+		String parentPath = currentPath + "." + setting.getPropertyName();
+		String parentOid = null;
+		if (StringUtil.isEmpty(childOid)) {
+			if (setting.getParent() != null && StringUtil.isNotEmpty(setting.getParent().getPropertyName())) {
+				//更に上位がいれば先に生成
+				initParent(comboList, setting.getParent(), parentProperty, parentPath, parentOid);
+			}
+			
+		} else {
+			// 子から親の選択値を検索
+			Entity parentEntity = searchParent(currentEntityDefinition, parentProperty, childOid);
+			parentOid = parentEntity != null ? parentEntity.getOid() : null;
+			
+			if (setting.getParent() != null && StringUtil.isNotEmpty(setting.getParent().getPropertyName())) {
+				//更に上位がいれば先に生成
+				initParent(comboList, setting.getParent(), parentProperty, parentPath, parentOid);
+			}
+		}
+		
+		ReferenceComboData comboData = new ReferenceComboData(parentPath);
+		comboData.setEntityName(parentProperty.getObjectDefinitionName());
+		if (setting.getParent() != null && StringUtil.isNotEmpty(setting.getParent().getPropertyName())) {
+			comboData.setParentPropertyName(setting.getParent().getPropertyName());
+		} 
+		comboData.setCondition(setting.getCondition());
+		comboData.setDisplayLabelItem(setting.getDisplayLabelItem());
+		comboData.setSortItem(setting.getSortItem());
+		comboData.setSortType(setting.getSortType());
+		comboData.setCurrentValue(parentOid);
+		comboList.add(comboData);
+	}
+
+	/**
+	 * 上位階層の選択データの取得
+	 *
+	 * 子階層の選択値から親階層の選択値を取得します。
+	 *
+	 * @param currentEntityDefinition 子階層のEntity定義
+	 * @param parentProperty 親の参照プロパティ定義
+	 * @param childOid 子階層の選択OID
+	 * @return 上位階層の選択データ
+	 */
+	Entity searchParent(EntityDefinition currentEntityDefinition, ReferenceProperty parentProperty, String childOid) {
+		if (parentProperty != null) {
+			//子階層のEntityデータを検索し、その親階層のデータを取得
+			Query query = new Query()
+					.select(parentProperty.getName() + "." + Entity.OID)
+					.from(currentEntityDefinition.getName())
+					.where(new Equals(Entity.OID, childOid));
+			Entity ret = em.searchEntity(query).getFirst();
+			if (ret != null && ret.getValue(parentProperty.getName()) != null) {
+				//最初の項目をデフォルト選択させる
+				Entity ref = ret.getValue(parentProperty.getName());
+				return ref;
+			}
+		}
+		return null;
+	}
+	
+	/**
+	 * コンボの選択オプション値の取得
+	 * 
+	 * 上位の選択値をもとに、オプション値を取得します。
+	 * 
+	 * @param comboData コンボ情報
+	 * @param parentOid 親階層の選択OID
+	 */
+	void searchOptionValues(ReferenceComboData comboData, String parentOid) {
+
+		Query query = new Query();
+		query.select(Entity.OID);
+		if (comboData.getDisplayLabelItem() != null) {
+			// 表示ラベルとして扱うプロパティ
+			query.select().add(comboData.getDisplayLabelItem());
+		} else {
+			query.select().add(Entity.NAME);
+		}
+		query.from(comboData.getEntityName());
+		
+		List<Condition> conditions = new ArrayList<>();
+		// デフォルト条件
+		if (comboData.getCondition() != null) {
+			conditions.add(new PreparedQuery(comboData.getCondition()).condition(null));
+		}
+		// 上位選択条件
+		if (StringUtil.isNotEmpty(parentOid)) {
+			conditions.add(new Equals(comboData.getParentPropertyName() + "." + Entity.OID, parentOid));
+		}
+		
+		if (!conditions.isEmpty()) {
+			And and = new And(conditions);
+			query.where(and);
+		}
+
+		String sortItem = comboData.getSortItem();
+		if (sortItem == null || sortItem.isEmpty()) {
+			sortItem = Entity.OID;
+		}
+		SortType sortType = null;
+		if (comboData.getSortType() == null || comboData.getSortType() == RefSortType.ASC) {
+			sortType = SortType.ASC;
+		} else {
+			sortType = SortType.DESC;
+		}
+		query.order(new SortSpec(sortItem, sortType));
+
+		final List<Entity> optionValues = new ArrayList<>();
+		em.searchEntity(query, (entity) -> {
+			if (comboData.getDisplayLabelItem() != null) {
+				// 表示ラベルとして扱うプロパティをNameに設定
+				entity.setName(entity.getValue(comboData.getDisplayLabelItem()));
+			}
+			optionValues.add(entity);
+			return true;
+		});
+		comboData.setOptionValues(optionValues);
+	}
+%>
 <%
 	ReferencePropertyEditor editor = (ReferencePropertyEditor) request.getAttribute(Constants.EDITOR_EDITOR);
 
+	if (editor.getReferenceComboSetting() == null) {
+		return;
+	}
+	ReferenceComboSetting setting = editor.getReferenceComboSetting();
+	
 	Entity entity = request.getAttribute(Constants.ENTITY_DATA) instanceof Entity ? (Entity) request.getAttribute(Constants.ENTITY_DATA) : null;
 	Object propValue = request.getAttribute(Constants.EDITOR_PROP_VALUE);
 	ReferenceProperty pd = (ReferenceProperty) request.getAttribute(Constants.EDITOR_PROPERTY_DEFINITION);
@@ -49,24 +263,83 @@
 	String rootOid = rootEntity != null ? rootEntity.getOid() : "";
 	String rootVersion = rootEntity != null && rootEntity.getVersion() != null ? rootEntity.getVersion().toString() : "";
 
+	Boolean nest = (Boolean) request.getAttribute(Constants.EDITOR_REF_NEST);
+	if (nest == null) nest = false;
+
+	// NestTable参照元プロパティ名
+	String nestPropertyName = "";
+	if (nest) {
+		nestPropertyName = (String)request.getAttribute(Constants.EDITOR_REF_NEST_PROP_NAME) + ".";
+	}
+
+	// プロパティ名(フルパス)
+	String propertyName = nestPropertyName + pd.getName();
+
 	//カスタムスタイル
 	String customStyle = "";
 	if (StringUtil.isNotEmpty(editor.getInputCustomStyle())) {
 		customStyle = EntityViewUtil.getCustomStyle(rootDefName, scriptKey, editor.getInputCustomStyleScriptKey(), entity, propValue);
 	}
 
+	String pleaseSelectLabel = "";
+	if (ViewUtil.isShowPulldownPleaseSelectLabel()) {
+		pleaseSelectLabel = GemResourceBundleUtil.resourceString("generic.editor.reference.ReferencePropertyEditor_Edit.pleaseSelect");
+	}
+
 	if (pd.getMultiplicity() == 1) {
 		Entity refEntity = propValue instanceof Entity ? (Entity) propValue : null;
 		String oid = refEntity != null ? refEntity.getOid() != null ? refEntity.getOid() : "" : "";
+		
+		// コンボ情報取得
+		List<ReferenceComboData> comboList = getComboList(editor, pd, propertyName, oid);
+		
+		for (int i = 0; i < comboList.size(); i++) {
+			ReferenceComboData comboData = comboList.get(i);
+			if (i != comboList.size() - 1) {
+				// 上位コンボ
 %>
-<select name="${m:esc(editor.propertyName)}" class="form-size-02 inpbr refCombo" style="<c:out value="<%=customStyle%>"/>" data-oid="<c:out value="<%=oid%>"/>"
- data-propName="${m:esc(propertyDefinition.name)}" data-defName="${m:esc(defName)}"
- data-viewName="<%=viewName %>" data-webapiName="<%=ReferenceComboCommand.WEBAPI_NAME%>"
- data-getEditorWebapiName="<%=GetEditorCommand.WEBAPI_NAME %>" data-searchParentWebapiName="<%=SearchParentCommand.WEBAPI_NAME %>"
- data-viewType="<%=Constants.VIEW_TYPE_DETAIL %>" data-prefix="" data-searchType="NONE" data-upperName="" data-upperOid="" data-customStyle="<c:out value="<%=customStyle%>"/>"
- data-entityOid="<%=StringUtil.escapeJavaScript(rootOid)%>" data-entityVersion="<%=StringUtil.escapeJavaScript(rootVersion)%>">
+<select name="<c:out value="<%=comboData.getPropertyPath()%>"/>" 
+  class="form-size-02 inpbr" style="<c:out value="<%=customStyle%>"/>" 
+  data-norewrite="true"
+>
+<%
+			} else {
+				// 最下層コンボ
+%>
+<select name="${m:esc(editor.propertyName)}" class="form-size-02 inpbr ref-combo-sync" style="<c:out value="<%=customStyle%>"/>"
+ data-defName="<c:out value="<%=rootDefName%>"/>"
+ data-viewName="<%=viewName %>" 
+ data-propName="<c:out value="<%=propertyName%>"/>" 
+ data-viewType="<%=Constants.VIEW_TYPE_DETAIL %>" 
+ data-entityOid="<%=StringUtil.escapeJavaScript(rootOid)%>" 
+ data-entityVersion="<%=StringUtil.escapeJavaScript(rootVersion)%>"
+ data-webapiName="<%=ReferenceComboCommand.WEBAPI_NAME%>"
+>
+<%
+			}
+			
+			// 選択肢の出力
+%>
+<option value=""><%= pleaseSelectLabel %></option>
+<%
+			for (Entity optionValue : comboData.getOptionValues()) {
+				String selected = optionValue.getOid().equals(comboData.getCurrentValue()) ? " selected" : "";
+%>
+<option value="<c:out value="<%=optionValue.getOid() %>"/>" <c:out value="<%=selected %>"/>>
+<c:out value="<%=optionValue.getName() %>" />
+</option>
+<%
+			}
+%>
 </select>
 <%
+			if (i != comboList.size() - 1) {
+				// 上位コンボ
+%>
+&gt; 
+<%
+			}
+		}
 	} else {
 		String ulId = "ul_" + editor.getPropertyName();
 		int length = 0;
@@ -76,13 +349,24 @@
 %>
 <ul id="<c:out value="<%=ulId %>"/>" class="mb05">
 <li id="<c:out value="<%=dummyRowId %>"/>" style="display: none;">
-<select class="form-size-02 inpbr" style="<c:out value="<%=customStyle%>"/>" data-oid=""
- data-propName="${m:esc(propertyDefinition.name)}" data-defName="${m:esc(defName)}"
- data-viewName="<%=viewName %>" data-webapiName="<%=ReferenceComboCommand.WEBAPI_NAME%>"
- data-getEditorWebapiName="<%=GetEditorCommand.WEBAPI_NAME %>" data-searchParentWebapiName="<%=SearchParentCommand.WEBAPI_NAME %>"
- data-viewType="<%=Constants.VIEW_TYPE_DETAIL %>" data-prefix="" data-searchType="NONE" data-upperName="" data-upperOid="" data-customStyle="<c:out value="<%=customStyle%>"/>"
- data-entityOid="<%=StringUtil.escapeJavaScript(rootOid)%>" data-entityVersion="<%=StringUtil.escapeJavaScript(rootVersion)%>">
-</select> <input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_RefCombo.delete')}" class="gr-btn-02 del-btn" />
+<select class="form-size-02 inpbr" style="<c:out value="<%=customStyle%>"/>"
+ data-defName="<c:out value="<%=rootDefName%>"/>"
+ data-viewName="<%=viewName %>" 
+ data-propName="<c:out value="<%=propertyName%>"/>" 
+ data-viewType="<%=Constants.VIEW_TYPE_DETAIL %>" 
+ data-entityOid="<%=StringUtil.escapeJavaScript(rootOid)%>" 
+ data-entityVersion="<%=StringUtil.escapeJavaScript(rootVersion)%>"
+ data-webapiName="<%=ReferenceComboCommand.WEBAPI_NAME%>"
+ data-getComboSettingWebapiName="<%=GetReferenceComboSettingCommand.WEBAPI_NAME %>" 
+ data-searchParentWebapiName="<%=SearchParentCommand.WEBAPI_NAME %>"
+ data-prefix="" 
+ data-searchType="NONE" 
+ data-oid=""
+ data-upperName="" 
+ data-upperOid="" 
+ data-customStyle="<c:out value="<%=customStyle%>"/>">
+</select>
+<input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_RefCombo.delete')}" class="gr-btn-02 del-btn" />
 </li>
 <%
 		//データ出力
@@ -98,12 +382,22 @@
 					+ ")";
 %>
 <li id="<c:out value="<%=liId %>"/>">
-<select name="${m:esc(editor.propertyName)}" class="form-size-02 inpbr refCombo" style="<c:out value="<%=customStyle%>"/>" data-oid="<c:out value="<%=oid%>"/>"
- data-propName="${m:esc(propertyDefinition.name)}" data-defName="${m:esc(defName)}"
- data-viewName="<%=viewName %>" data-webapiName="<%=ReferenceComboCommand.WEBAPI_NAME%>"
- data-getEditorWebapiName="<%=GetEditorCommand.WEBAPI_NAME %>" data-searchParentWebapiName="<%=SearchParentCommand.WEBAPI_NAME %>"
- data-viewType="<%=Constants.VIEW_TYPE_DETAIL %>" data-prefix="" data-searchType="NONE" data-upperName="" data-upperOid="" data-customStyle="<c:out value="<%=customStyle%>"/>"
- data-entityOid="<%=StringUtil.escapeJavaScript(rootOid)%>" data-entityVersion="<%=StringUtil.escapeJavaScript(rootVersion)%>">
+<select name="${m:esc(editor.propertyName)}" class="form-size-02 inpbr refCombo" style="<c:out value="<%=customStyle%>"/>"
+ data-defName="<c:out value="<%=rootDefName%>"/>"
+ data-viewName="<%=viewName %>" 
+ data-propName="<c:out value="<%=propertyName%>"/>"
+ data-viewType="<%=Constants.VIEW_TYPE_DETAIL %>" 
+ data-entityOid="<%=StringUtil.escapeJavaScript(rootOid)%>" 
+ data-entityVersion="<%=StringUtil.escapeJavaScript(rootVersion)%>"
+ data-webapiName="<%=ReferenceComboCommand.WEBAPI_NAME%>"
+ data-getComboSettingWebapiName="<%=GetReferenceComboSettingCommand.WEBAPI_NAME %>" 
+ data-searchParentWebapiName="<%=SearchParentCommand.WEBAPI_NAME %>"
+ data-prefix="" 
+ data-searchType="NONE" 
+ data-oid="<c:out value="<%=oid%>"/>"
+ data-upperName="" 
+ data-upperOid="" 
+ data-customStyle="<c:out value="<%=customStyle%>"/>">
 </select>
 <input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_RefCombo.delete')}" class="gr-btn-02 del-btn"
  onclick="<c:out value="<%=deleteItem %>"/>" />
@@ -113,7 +407,11 @@
 		}
 %>
 </ul>
-<input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_RefCombo.add')}" class="gr-btn-02 add-btn refComboController" data-multiplicity="${propertyDefinition.multiplicity}" data-ulId="<c:out value="<%=ulId %>"/>" data-dummyId="<c:out value="<%=dummyRowId %>"/>" data-propName="${m:esc(editor.propertyName)}" />
+<input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_RefCombo.add')}" class="gr-btn-02 add-btn refComboController" 
+ data-multiplicity="${propertyDefinition.multiplicity}" 
+ data-ulId="<c:out value="<%=ulId %>"/>" 
+ data-dummyId="<c:out value="<%=dummyRowId %>"/>" 
+ data-propName="${m:esc(editor.propertyName)}" />
 <%
 	}
 %>

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
@@ -4284,9 +4284,8 @@ function addNestRow_Reference(type, cell, idx) {
 		replaceDummyAttr($li, "data-propName", idx);
 		$(".refUnique", cell).refUnique();
 	} else if (type == "REFCOMBO") {
-		//TODO 連動コンボ時の初期ロードで実行されるjavascriptをどうにかする
-		cell.children("select").each(function() {
-		});
+		// 参照コンボの対応
+		$(".ref-combo-sync", cell).refComboSync();
 	}
 }
 

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/skin/flat/design.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/skin/flat/design.js
@@ -126,6 +126,7 @@ $(function() {
 
 	$(".massReference").massReferenceTable();
 	$(".refCombo").refCombo();
+	$(".ref-combo-sync").refComboSync();
 	$(".refComboController").refComboController();
 	$(".recursiveTreeTrigger").refRecursiveTree();
 	$(".refLinkSelect").refLinkSelect();

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/skin/horizontal/design.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/skin/horizontal/design.js
@@ -114,6 +114,7 @@ $(function(){
 
 	$(".massReference").massReferenceTable();
 	$(".refCombo").refCombo();
+	$(".ref-combo-sync").refComboSync();
 	$(".refComboController").refComboController();
 	$(".recursiveTreeTrigger").refRecursiveTree();
 	$(".refLinkSelect").refLinkSelect();

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/skin/vertical/design.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/skin/vertical/design.js
@@ -133,6 +133,7 @@ $(function(){
 
 	$(".massReference").massReferenceTable();
 	$(".refCombo").refCombo();
+	$(".ref-combo-sync").refComboSync();
 	$(".refComboController").refComboController();
 	$(".recursiveTreeTrigger").refRecursiveTree();
 	$(".refLinkSelect").refLinkSelect();

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/webapi.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/webapi.js
@@ -673,7 +673,7 @@ function _lock(webapi, defName, viewName, oid, token, func) {
 }
 
 ////////////////////////////////////////////////////////
-//連動コンボ用のJavascript
+//参照コンボ用のJavascript
 ////////////////////////////////////////////////////////
 function refComboChange(webapi, defName, viewName, propName, _params, viewType, func) {
 	var params = "{";
@@ -692,6 +692,9 @@ function refComboChange(webapi, defName, viewName, propName, _params, viewType, 
 	});
 }
 
+/**
+ @deprecated use getReferenceComboSetting
+ */
 function getPropertyEditor(webapi, defName, viewName, propName, viewType, entityOid, entityVersion, func) {
 	var params = "{";
 	params += "\"defName\":\"" + defName + "\"";
@@ -711,23 +714,42 @@ function getPropertyEditor(webapi, defName, viewName, propName, viewType, entity
 	});
 }
 
-function searchParent(webapi, defName, viewName, propName, viewType, currentName, oid, entityOid, entityVersion, func) {
-	var params = "{";
+function getReferenceComboSetting(webapi, defName, viewName, propName, viewType, entityOid, entityVersion, func) {
+	let params = "{";
 	params += "\"defName\":\"" + defName + "\"";
 	params += ",\"viewName\":\"" + viewName + "\"";
 	params += ",\"propName\":\"" + propName + "\"";
 	params += ",\"viewType\":\"" + viewType + "\"";
-	params += ",\"currentName\":\"" + currentName + "\"";
-	params += ",\"oid\":\"" + oid + "\"";
+	if (typeof entityOid !== "undefined" && entityOid != null) {
+		params += ",\"entityOid\":\"" + entityOid + "\"";
+	}
+	if (typeof entityVersion !== "undefined" && entityVersion != null) {
+		params += ",\"entityVersion\":\"" + entityVersion + "\"";
+	}
+	params += "}";
+	postAsync(webapi, params, function(results) {
+		const setting = results.setting;
+		if (func && $.isFunction(func)) func.call(this, setting);
+	});
+}
+
+function searchParent(webapi, defName, viewName, propName, viewType, targetPath, childOid, entityOid, entityVersion, func) {
+	let params = "{";
+	params += "\"defName\":\"" + defName + "\"";
+	params += ",\"viewName\":\"" + viewName + "\"";
+	params += ",\"propName\":\"" + propName + "\"";
+	params += ",\"viewType\":\"" + viewType + "\"";
 	if (typeof entityOid !== "undefined" && entityOid !== null) {
 		params += ",\"entityOid\":\"" + entityOid + "\"";
 	}
 	if (typeof entityVersion !== "undefined" && entityVersion !== null) {
 		params += ",\"entityVersion\":\"" + entityVersion + "\"";
 	}
+	params += ",\"targetPath\":\"" + targetPath + "\"";
+	params += ",\"childOid\":\"" + childOid + "\"";
 	params += "}";
 	postAsync(webapi, params, function(results) {
-		var parent = results.parent;
+		const parent = results.parent;
 		if (func && $.isFunction(func)) func.call(this, parent);
 	});
 }


### PR DESCRIPTION
https://github.com/ISID/iPLAss/issues/1382 対応

- 多重度1の場合はサーバ側でコンボを生成(refComboSync)
- 検索画面、編集画面の多重度複数の場合は現状通りWebApiで生成(refCombo)

- WebApiでコンボ生成時にEditorを取得していたところをコンボ設定を取得するように変更
　これに伴い、GetEditorCommandを `deprecated` 指定。