### PR TITLE
WebApiとActionMappingのアノテーションのタイプミス修正

### DIFF
--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/action/ActionAttributePane.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/action/ActionAttributePane.java
@@ -59,7 +59,7 @@ public class ActionAttributePane extends HLayout {
 	/** 部品（直接呼び出し不可） */
 	private CheckboxItem partsField;
 	/** 特権実行（セキュリティ制約を受けない） */
-	private CheckboxItem privilagedField;
+	private CheckboxItem privilegedField;
 	/** 公開Action */
 	private CheckboxItem publicActionField;
 	/** sessionにて同期を行うか否か */
@@ -121,9 +121,9 @@ public class ActionAttributePane extends HLayout {
 		partsField.setShowTitle(false);
 		partsField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_errDirectAccess")));
 
-		privilagedField = new CheckboxItem("privilaged", "privilege execute");
-		privilagedField.setShowTitle(false);
-		privilagedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_privilExecution")));
+		privilegedField = new CheckboxItem("privileged", "privilege execute");
+		privilegedField.setShowTitle(false);
+		privilegedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_privilExecution")));
 
 		publicActionField = new CheckboxItem("publicActionField", "public action");
 		publicActionField.setShowTitle(false);
@@ -137,7 +137,7 @@ public class ActionAttributePane extends HLayout {
 		needTrustedAuthenticateField.setShowTitle(false);
 		needTrustedAuthenticateField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_action_ActionAttributePane_needTrustedAuthenticate")));
 
-		accessForm.setItems(partsField, privilagedField, publicActionField, synchronizeOnSessionField, needTrustedAuthenticateField);
+		accessForm.setItems(partsField, privilegedField, publicActionField, synchronizeOnSessionField, needTrustedAuthenticateField);
 
 
 		tokenForm = new DynamicForm();
@@ -249,7 +249,7 @@ public class ActionAttributePane extends HLayout {
 		}
 
 		partsField.setValue(definition.isParts());
-		privilagedField.setValue(definition.isPrivilaged());
+		privilegedField.setValue(definition.isPrivileged());
 		publicActionField.setValue(definition.isPublicAction());
 		synchronizeOnSessionField.setValue(definition.isSynchronizeOnSession());
 		needTrustedAuthenticateField.setValue(definition.isNeedTrustedAuthenticate());
@@ -308,7 +308,7 @@ public class ActionAttributePane extends HLayout {
 		definition.setAllowMethod(methodType);
 
 		definition.setParts(SmartGWTUtil.getBooleanValue(partsField));
-		definition.setPrivilaged(SmartGWTUtil.getBooleanValue(privilagedField));
+		definition.setPrivileged(SmartGWTUtil.getBooleanValue(privilegedField));
 		definition.setPublicAction(SmartGWTUtil.getBooleanValue(publicActionField));
 		definition.setSynchronizeOnSession(SmartGWTUtil.getBooleanValue(synchronizeOnSessionField));
 		definition.setNeedTrustedAuthenticate(SmartGWTUtil.getBooleanValue(needTrustedAuthenticateField));

--- a/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/webapi/WebApiAttributePane.java
+++ b/iplass-admin/src/main/java/org/iplass/adminconsole/client/metadata/ui/webapi/WebApiAttributePane.java
@@ -62,7 +62,7 @@ public class WebApiAttributePane extends HLayout {
 	private CheckboxItem deleteMethod;
 
 	/** 特権実行（セキュリティ制約を受けない） */
-	private CheckboxItem privilagedField;
+	private CheckboxItem privilegedField;
 
 	/** 公開WebAPI */
 	private CheckboxItem publicWebAPIField;
@@ -123,8 +123,8 @@ public class WebApiAttributePane extends HLayout {
 		accessForm.setIsGroup(true);
 		accessForm.setGroupTitle("Access Policy");
 
-		privilagedField = new CheckboxItem("privilaged", "Privilege execute");
-		privilagedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_webapi_WebAPIAttributePane_privilExecution")));
+		privilegedField = new CheckboxItem("privileged", "Privilege execute");
+		privilegedField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_webapi_WebAPIAttributePane_privilExecution")));
 
 		publicWebAPIField = new CheckboxItem("publicWebAPI", "Public WebAPI");
 		publicWebAPIField.setTooltip(SmartGWTUtil.getHoverString(AdminClientMessageUtil.getString("ui_metadata_webapi_WebAPIAttributePane_publicWebAPI")));
@@ -145,7 +145,7 @@ public class WebApiAttributePane extends HLayout {
 		stateTypeMap.put(StateType.STATELESS.toString(), StateType.STATELESS.toString());
 		stateTypeField.setValueMap(stateTypeMap);
 
-		accessForm.setItems(privilagedField, publicWebAPIField, checkXRequestedWithHeaderField,
+		accessForm.setItems(privilegedField, publicWebAPIField, checkXRequestedWithHeaderField,
 				synchronizeOnSessionField, stateTypeField);
 
 		tokenForm = new DynamicForm();
@@ -245,7 +245,7 @@ public class WebApiAttributePane extends HLayout {
 			}
 		}
 
-		privilagedField.setValue(definition.isPrivilaged());
+		privilegedField.setValue(definition.isPrivileged());
 		publicWebAPIField.setValue(definition.isPublicWebApi());
 		checkXRequestedWithHeaderField.setValue(definition.isCheckXRequestedWithHeader());
 		synchronizeOnSessionField.setValue(definition.isSynchronizeOnSession());
@@ -309,7 +309,7 @@ public class WebApiAttributePane extends HLayout {
 			i++;
 		}
 		definition.setMethods(methodType);
-		definition.setPrivilaged(SmartGWTUtil.getBooleanValue(privilagedField));
+		definition.setPrivileged(SmartGWTUtil.getBooleanValue(privilegedField));
 		definition.setPublicWebApi(SmartGWTUtil.getBooleanValue(publicWebAPIField));
 		definition.setCheckXRequestedWithHeader(SmartGWTUtil.getBooleanValue(checkXRequestedWithHeaderField));
 		definition.setSynchronizeOnSession(SmartGWTUtil.getBooleanValue(synchronizeOnSessionField));

--- a/iplass-gem/src/main/java/org/iplass/gem/command/auth/LoginCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/auth/LoginCommand.java
@@ -57,13 +57,13 @@ import org.slf4j.LoggerFactory;
 @ActionMappings({
 	@ActionMapping(name=LoginCommand.ACTION_VIEW_LOGIN,
 			clientCacheType=ClientCacheType.NO_CACHE,
-			privilaged=true,
+			privileged=true,
 			command={},
 			result=@Result(type=Type.TEMPLATE, value=Constants.TEMPLATE_LOGIN)),
 	@ActionMapping(name=LoginCommand.ACTION_LOGIN,
 			allowMethod=HttpMethodType.POST,
 			clientCacheType=ClientCacheType.NO_CACHE,
-			privilaged=true,
+			privileged=true,
 			result={
 				@Result(status=Constants.CMD_EXEC_SUCCESS, type=Type.REDIRECT, value="mtp.auth.redirectPath"),
 				@Result(status=LoginCommand.CMD_EXEC_EXPIRE, type=Type.TEMPLATE, value=Constants.TEMPLATE_PASSWORD_EXPIRE),

--- a/iplass-gem/src/main/java/org/iplass/gem/command/auth/LogoutCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/auth/LogoutCommand.java
@@ -33,7 +33,7 @@ import org.iplass.mtp.web.template.TemplateUtil;
 
 @ActionMapping(name=LogoutCommand.ACTION_LOOUT,
 		clientCacheType=ClientCacheType.NO_CACHE,
-		privilaged=true,
+		privileged=true,
 		result={@Result(status="SUCCESS", type=Type.REDIRECT, value=LogoutCommand.RESULT_REDIRECT_PATH)
 })
 @CommandClass(name="gem/auth/LogoutCommand", displayName="ログアウト処理")

--- a/iplass-gem/src/main/java/org/iplass/gem/command/auth/UpdateExpirePasswordCommand.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/auth/UpdateExpirePasswordCommand.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 @ActionMapping(name=UpdateExpirePasswordCommand.ACTION_UPDATE_EXP_PASSWORD,
 		allowMethod=HttpMethodType.POST,
 		clientCacheType=ClientCacheType.NO_CACHE,
-		privilaged=true,
+		privileged=true,
 		command=@CommandConfig("cmd.checkLoginToken=true"),
 		result={
 			@Result(status="SUCCESS", type=Type.REDIRECT, value="mtp.auth.redirectPath"),

--- a/iplass-web/src/main/java/org/iplass/mtp/command/annotation/action/ActionMapping.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/command/annotation/action/ActionMapping.java
@@ -111,12 +111,23 @@ public @interface ActionMapping {
 	 * publicActionとの違いは、Entity権限など、すべての権限が許可された状態で実行されます。
 	 * 
 	 * @return
+	 * @deprecated {@link #privileged()} を使用してください。
 	 */
+	@Deprecated
 	boolean privilaged() default false;
+	
+	/**
+	 * このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうかを設定します。
+	 * デフォルトはfalseです。
+	 * publicActionとの違いは、Entity権限など、すべての権限が許可された状態で実行されます。
+	 * 
+	 * @return
+	 */
+	boolean privileged() default false;
 
 	/**
 	 * このActionの呼び出しをAction権限設定によらず呼び出し可能にする場合は、trueを設定します。
-	 * isPrivilagedとの違いは、Entityの操作などAction権限以外の権限がチェックされる状況においては、
+	 * isPrivilegedとの違いは、Entityの操作などAction権限以外の権限がチェックされる状況においては、
 	 * セキュリティ制約を受けます。
 	 * デフォルトはfalseです。
 	 * 

--- a/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/command/annotation/webapi/WebApi.java
@@ -69,12 +69,18 @@ public @interface WebApi {
 	long cacheControlMaxAge() default -1;
 
 	boolean checkXRequestedWithHeader() default true;
+	/** @deprecated {@link #privileged()} を使用してください。 */
+	@Deprecated
 	boolean privilaged() default false;
+	boolean privileged() default false;
 	boolean publicWebApi() default false;
 	boolean overwritable() default true;
 	boolean permissionSharable() default false;
 
+	/** @deprecated {@link #accessControlAllowOrigin()} を使用してください。 */
+	@Deprecated
 	String accessControlAllowOrign() default "";
+	String accessControlAllowOrigin() default "";
 	boolean accessControlAllowCredentials() default false;
 	boolean needTrustedAuthenticate() default false;
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/oidc/command/AuthCallbackCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/oidc/command/AuthCallbackCommand.java
@@ -40,7 +40,7 @@ import org.iplass.mtp.web.WebRequestConstants;
 @ActionMapping(name=AuthCallbackCommand.ACTION_NAME,
 	clientCacheType=ClientCacheType.NO_CACHE,
 	publicAction=true,
-	privilaged=true,
+	privileged=true,
 	paramMapping={
 			@ParamMapping(name=AuthCallbackCommand.PARAM_DEFINITION_NAME, mapFrom=ParamMapping.PATHS)
 	},

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/IntrospectCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/IntrospectCommand.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
 	accepts=RequestType.REST_FORM,
 	methods=MethodType.POST,
 	checkXRequestedWithHeader=false,
-	privilaged=true,
+	privileged=true,
 	state=StateType.STATELESS,
 	responseType="application/json"
 )

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/RevokeCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/RevokeCommand.java
@@ -34,7 +34,7 @@ import org.iplass.mtp.webapi.definition.StateType;
 	accepts=RequestType.REST_FORM,
 	methods=MethodType.POST,
 	checkXRequestedWithHeader=false,
-	privilaged=true,
+	privileged=true,
 	state=StateType.STATELESS,
 	responseType="application/json"
 )

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/TokenCommand.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/command/TokenCommand.java
@@ -50,7 +50,7 @@ import org.iplass.mtp.webapi.definition.StateType;
 	accepts=RequestType.REST_FORM,
 	methods=MethodType.POST,
 	checkXRequestedWithHeader=false,
-	privilaged=true,
+	privileged=true,
 	state=StateType.STATELESS,
 	cacheControlType=CacheControlType.NO_CACHE,
 	responseType="application/json"

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMapping.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMapping.java
@@ -99,9 +99,9 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 	private boolean isParts;
 
 	/** このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged = false;
+	private boolean isPrivileged = false;
 
-	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicAction;
 
 	/** このActionMappingが呼び出されたときに実行するCommand。未指定可（Commandは実行せずテンプレートを表示）。 */
@@ -221,12 +221,24 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		this.isPublicAction = isPublicAction;
 	}
 
+	/** @deprecated {@link #isPrivileged()} を使用してください。 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	/** @deprecated {@link #setPrivileged(boolean)} を使用してください。 */
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 	public ParamMap[] getParamMap() {
@@ -299,7 +311,13 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		clientCacheMaxAge = definition.getClientCacheMaxAge();
 
 		isParts = definition.isParts();
-		isPrivilaged = definition.isPrivilaged();
+		
+		if (definition.isPrivileged()) {
+			isPrivileged = definition.isPrivileged();
+		} else {
+			isPrivileged = definition.isPrivilaged();
+		}
+		
 		isPublicAction = definition.isPublicAction();
 
 		if (definition.getCommandConfig() != null) {
@@ -383,7 +401,8 @@ public class MetaActionMapping extends BaseRootMetaData implements DefinableMeta
 		definition.setClientCacheType(clientCacheType);
 		definition.setClientCacheMaxAge(clientCacheMaxAge);
 		definition.setParts(isParts);
-		definition.setPrivilaged(isPrivilaged);
+		definition.setPrivilaged(isPrivileged);
+		definition.setPrivileged(isPrivileged);
 		definition.setPublicAction(isPublicAction);
 
 		if (command != null) {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMappingFactory.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/actionmapping/MetaActionMappingFactory.java
@@ -304,7 +304,12 @@ public class MetaActionMappingFactory implements
 		
 		metaActionMapping.setNeedTrustedAuthenticate(actionMapping.needTrustedAuthenticate());
 		metaActionMapping.setParts(actionMapping.parts());
-		metaActionMapping.setPrivilaged(actionMapping.privilaged());
+		metaActionMapping.setPrivileged(actionMapping.privileged());
+		if (actionMapping.privileged()) {
+			metaActionMapping.setPrivilaged(actionMapping.privileged());
+		} else {
+			metaActionMapping.setPrivilaged(actionMapping.privilaged());
+		}
 		metaActionMapping.setPublicAction(actionMapping.publicAction());
 
 		if (actionMapping.paramMapping().length > 0) {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/web/interceptors/AuthInterceptor.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/web/interceptors/AuthInterceptor.java
@@ -101,9 +101,14 @@ public class AuthInterceptor implements RequestInterceptor,ServiceInitListener<A
 	public void destroyed() {
 	}
 	private AuthContextHolder getAuthContextHolder(ActionMappingRuntime action) {
-		if (action.getMetaData().isPrivilaged()) {
+		if (action.getMetaData().isPrivileged()) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("do as privilaged action:" + action.getMetaData().getName());
+				logger.debug("do as Privileged action:" + action.getMetaData().getName());
+			}
+			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
+		} else if (action.getMetaData().isPrivilaged()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("do as Privilaged action:" + action.getMetaData().getName());
 			}
 			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
 		} else {

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApi.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApi.java
@@ -109,9 +109,9 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 	private String restXmlParameterName = null;
 
 	/** このWebAPIで処理されるCommandを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged = false;
+	private boolean isPrivileged = false;
 
-	/** このWebAPIの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このWebAPIの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicWebApi;
 
 	/** Tokenチェックの実行設定。未指定可(Tokenチェックは実行されない)。 */
@@ -249,12 +249,24 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 		this.tokenCheck = tokenCheck;
 	}
 
+	/** @deprecated {@link #isPrivileged()} を使用してください。 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	/** @deprecated {@link #setPrivileged(boolean)} を使用してください。 */
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 	public boolean isPublicWebApi() {
@@ -794,7 +806,8 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 		definition.setCacheControlType(cacheControlType);
 		definition.setCacheControlMaxAge(cacheControlMaxAge);
 
-		definition.setPrivilaged(isPrivilaged);
+		definition.setPrivilaged(isPrivileged);
+		definition.setPrivileged(isPrivileged);
 		definition.setPublicWebApi(isPublicWebApi);
 		definition.setCheckXRequestedWithHeader(isCheckXRequestedWithHeader);
 
@@ -848,7 +861,13 @@ public class MetaWebApi extends BaseRootMetaData implements DefinableMetaData<We
 			results = null;
 		}
 
-		isPrivilaged = definition.isPrivilaged();
+		if (definition.isPrivileged()) 
+		{
+			isPrivileged = definition.isPrivileged();
+		} else {
+			isPrivileged = definition.isPrivilaged();
+		}
+		
 		isPublicWebApi = definition.isPublicWebApi();
 		isCheckXRequestedWithHeader = definition.isCheckXRequestedWithHeader();
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/MetaWebApiFactory.java
@@ -30,6 +30,7 @@ import org.iplass.mtp.impl.command.MetaCommand;
 import org.iplass.mtp.impl.command.MetaCommandFactory;
 import org.iplass.mtp.impl.metadata.annotation.AnnotatableMetaDataFactory;
 import org.iplass.mtp.impl.metadata.annotation.AnnotateMetaDataEntry;
+import org.iplass.mtp.util.StringUtil;
 import org.iplass.mtp.webapi.definition.CacheControlType;
 
 
@@ -145,7 +146,12 @@ public class MetaWebApiFactory implements AnnotatableMetaDataFactory<WebApi, Obj
 		if (webapi.oauthScopes() != null && webapi.oauthScopes().length > 0) {
 			meta.setOauthScopes(webapi.oauthScopes());
 		}
-		meta.setPrivilaged(webapi.privilaged());
+		meta.setPrivileged(webapi.privileged());
+		if (webapi.privileged()) {
+			meta.setPrivilaged(webapi.privileged());
+		} else {
+			meta.setPrivilaged(webapi.privilaged());
+		}
 		meta.setPublicWebApi(webapi.publicWebApi());
 		meta.setCheckXRequestedWithHeader(webapi.checkXRequestedWithHeader());
 		meta.setResponseType(webapi.responseType());
@@ -172,7 +178,11 @@ public class MetaWebApiFactory implements AnnotatableMetaDataFactory<WebApi, Obj
 		}
 
 		meta.setSynchronizeOnSession(webapi.synchronizeOnSession());
-		meta.setAccessControlAllowOrigin(webapi.accessControlAllowOrign());
+		if (StringUtil.isNotBlank(webapi.accessControlAllowOrigin())) {
+			meta.setAccessControlAllowOrigin(webapi.accessControlAllowOrigin());
+		} else {
+			meta.setAccessControlAllowOrigin(webapi.accessControlAllowOrign());
+		}
 		meta.setAccessControlAllowCredentials(webapi.accessControlAllowCredentials());
 		meta.setNeedTrustedAuthenticate(webapi.needTrustedAuthenticate());
 

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/interceptors/AuthInterceptor.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/interceptors/AuthInterceptor.java
@@ -63,9 +63,14 @@ public class AuthInterceptor implements CommandInterceptor {
 	private SessionService sessionService = ServiceRegistry.getRegistry().getService(SessionService.class);
 
 	private AuthContextHolder getAuthContextHolder(WebApiRuntime webapi) {
-		if (webapi.getMetaData().isPrivilaged()) {
+		if (webapi.getMetaData().isPrivileged()) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("do as privilaged webapi:" + webapi.getMetaData().getName());
+				logger.debug("do as Privileged webapi:" + webapi.getMetaData().getName());
+			}
+			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
+		} else if (webapi.getMetaData().isPrivilaged()) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("do as Privilaged webapi:" + webapi.getMetaData().getName());
 			}
 			return AuthContextHolder.getAuthContext().privilegedAuthContextHolder();
 		} else {

--- a/iplass-web/src/main/java/org/iplass/mtp/web/actionmapping/definition/ActionMappingDefinition.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/web/actionmapping/definition/ActionMappingDefinition.java
@@ -67,9 +67,9 @@ public class ActionMappingDefinition implements Definition {
 	private boolean isParts;
 
 	/** このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged;
+	private boolean isPrivileged;
 	
-	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicAction;
 
 	/**
@@ -195,7 +195,7 @@ public class ActionMappingDefinition implements Definition {
 
 	/**
 	 * このActionの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。
-	 * isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。
+	 * isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。
 	 * デフォルトはfalse。
 	 * 
 	 * @param isPublicAction
@@ -348,19 +348,41 @@ public class ActionMappingDefinition implements Definition {
 	/**
 	 * @see #setPrivilaged(boolean)
 	 * @return
+	 * @deprecated {@link #isPrivileged()} を使用してください。
 	 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
 	/**
 	 * このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうかを設定。
 	 * デフォルトはfalse。
 	 *
-	 * @param isPrivilaged
+	 * @param isPrivileged
+	 * @deprecated {@link #setPrivileged(boolean)} を使用してください。 
 	 */
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	/**
+	 * @see #setPrivileged(boolean)
+	 * @return
+	 */
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	/**
+	 * このActionMappingで処理されるCommand,Templateを特権（セキュリティ制約を受けない）にて処理するかどうかを設定。
+	 * デフォルトはfalse。
+	 *
+	 * @param isPrivileged
+	 */
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 

--- a/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/WebApiDefinition.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/webapi/definition/WebApiDefinition.java
@@ -55,9 +55,9 @@ public class WebApiDefinition implements Definition {
 	private WebApiParamMapDefinition[] webApiParamMap;
 
 	/** このWebApiで処理されるCommandを特権（セキュリティ制約を受けない）にて処理するかどうか。デフォルトはfalse。 */
-	private boolean isPrivilaged;
+	private boolean isPrivileged;
 
-	/** このWebApiの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
+	/** このWebApiの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定。 isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受ける。デフォルトはfalse。*/
 	private boolean isPublicWebApi;
 
 	/** XMLHttpRequestがセットされていることを確認するか。 */
@@ -420,7 +420,7 @@ public class WebApiDefinition implements Definition {
 
 	/**
 	 * このWebApiの呼び出しをセキュリティ設定によらず呼び出し可能にする場合は、trueを設定します。
-	 * isPrivilagedとの違いは、Entityの操作などにおいては、セキュリティ制約を受けます。
+	 * isPrivilegedとの違いは、Entityの操作などにおいては、セキュリティ制約を受けます。
 	 * デフォルトはfalseです。
 	 *
 	 * @param isPublicWebApi
@@ -432,17 +432,37 @@ public class WebApiDefinition implements Definition {
 	/**
 	 *
 	 * @return
+	 * @deprecated {@link #isPrivileged()} を使用してください。
 	 */
+	@Deprecated
 	public boolean isPrivilaged() {
-		return isPrivilaged;
+		return isPrivileged;
 	}
 
 	/**
 	 *
-	 * @param isPrivilaged
+	 * @param isPrivileged
+	 * @deprecated {@link #setPrivileged(boolean)} を使用してください。 
 	 */
-	public void setPrivilaged(boolean isPrivilaged) {
-		this.isPrivilaged = isPrivilaged;
+	@Deprecated
+	public void setPrivilaged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
+	}
+
+	/**
+	 *
+	 * @return
+	 */
+	public boolean isPrivileged() {
+		return isPrivileged;
+	}
+
+	/**
+	 *
+	 * @param isPrivileged
+	 */
+	public void setPrivileged(boolean isPrivileged) {
+		this.isPrivileged = isPrivileged;
 	}
 
 	/**


### PR DESCRIPTION
WebApiとActionMappingのアノテーションのタイプミスを修正する。
・間違ったスペル「privilaged」を「privileged」に修正する。
　間違ったスペルのモノはdeprecatedにして、残したままの状態にし、正しいスペルのモノを新たに追加する。 
・間違ったスペル「accessControlAllowOrign」を「accessControlAllowOrigin」に修正する。