### PR TITLE
GEM: ログインボタン押下後に非活性にする

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/auth/Login.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/auth/Login.jsp
@@ -65,12 +65,12 @@ boolean isRememberMe = ExecuteContext.getCurrentContext().getCurrentTenant().get
 <%@include file="../layout/resource/tenant.jsp" %>
 
 <script type="text/javascript">
-$(function() {
+$(() => {
 	const LOGIN_BUTTON_DISABLE_DURATION_MS = 60 * 1000;
 	const loginBtn = $("#loginBtn");
-	$('form[name="loginForm"]').on('submit', function(e) {
+	$('form[name="loginForm"]').on('submit', () => {
 		loginBtn.prop("disabled", true);
-		setTimeout(function() {
+		setTimeout(() => {
 			loginBtn.prop("disabled", false);
 		}, LOGIN_BUTTON_DISABLE_DURATION_MS);
 	});


### PR DESCRIPTION

## 対応内容

ログインボタン押下後に、ボタンを非活性にする

closes #1917

## 動作確認・スクリーンショット

1. http://localhost:8080/mtp/xxx/gem/auth/login を開く
2. 「ログイン」ボタンを連続で2回たたく
3. 2回目でエラーに**ならない**
<img width="1593" height="847" alt="2026-02-12_16h05_07" src="https://github.com/user-attachments/assets/9b91ebe1-11f8-4139-aa64-d4b9c0a2c634" />



## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
