### PR TITLE
GEM: ReferencePropertyEditorが表示タイプ「UNIQUE」かつ多重度=1の場合、削除ボタンが動作しない修正

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
@@ -1492,14 +1492,9 @@ $(function() {
 %>
 <script type="text/javascript">
 function <%=clearUniqueRefFunc%>() {
-	const $li = $("#" + es("<%=StringUtil.escapeJavaScript(liId)%>"));
 	const $txt = $("#uniq_txt_" + es("<%=StringUtil.escapeJavaScript(liId)%>"));
-	const $link = $("a.modal-lnk", $li);
-	const $hidden = $("#i_" + es("<%=StringUtil.escapeJavaScript(liId)%>"));
-	
 	$txt.val("");
-	$link.attr({"id":"", "data-linkId":""}).text("").hide();
-	$hidden.val("");
+	$txt.change();
 }
 </script>
 <input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_Edit.delete')}" class="gr-btn-02 del-btn"


### PR DESCRIPTION
## 対応内容

 多重度1の場合は、入力エリアを削除せず保持している値をクリアする。

fixes #1873

## レビュー観点・補足情報

- クリアした場合に、クリア前の入力データが登録されないことを確認する