### PR TITLE
GEM: ReferencePropertyEditorが表示タイプ「UNIQUE」かつ多重度=1の場合、未入力のリンクを表示しないようにする

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
@@ -1398,7 +1398,7 @@ $(function() {
 			String linkDisplayStyle = "";
 			String dispPropLabel = "";
 			String key = "";
-			// 多重度1で値が未指定の場合のダミーデータを除外
+			// 多重度1で値が未指定の場合の空エンティティは、リンクのIDを指定しない、非表示にする
 			if (refEntity.getOid() != null) {
 				linkId = propName + "_" + refEntity.getOid();
 				dispPropLabel = getDisplayPropLabel(editor, refEntity);


### PR DESCRIPTION
## 対応内容

初期表示時に値が未入力の場合は、リンクを非表示にする。
またリンクに付与するIDも空にする （ `null` が指定されないようにする）。

fixes #1949