### PR TITLE
GEM: ReferencePropertyEditorが表示タイプ「UNIQUE」かつ多重度=1の場合、削除ボタンが動作しない修正（3.2）

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
@@ -1421,8 +1421,18 @@ $(function() {
  onclick="<c:out value="<%=deleteItem %>"/>"/>
 <%
 				} else {
+					// 多重度が1の場合は、削除ではなく値をクリアする
+					String clearUniqueRefFunc = "clearUniqueBtn_" + StringUtil.escapeJavaScript(propName);
 %>
-<input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_Edit.delete')}" class="gr-btn-02 del-btn" />
+<script type="text/javascript">
+function <%=clearUniqueRefFunc%>() {
+	const $txt = $("#uniq_txt_" + es("<%=StringUtil.escapeJavaScript(liId)%>"));
+	$txt.val("");
+	$txt.change();
+}
+</script>
+<input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_Edit.delete')}" class="gr-btn-02 del-btn"
+ onclick="<c:out value="<%=clearUniqueRefFunc %>"/>()"/>
 <%
 				}
 			}


### PR DESCRIPTION
## 対応内容

 多重度1の場合は、入力エリアを削除せず保持している値をクリアする。

fixes #1885

## レビュー観点・補足情報

- クリアした場合に、クリア前の入力データが登録されないことを確認する