### PR TITLE
GEM: ReferencePropertyEditorが表示タイプ「UNIQUE」かつ多重度=1の場合、未入力のリンクを表示しないようにする（3.2）

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
@@ -1328,12 +1328,18 @@ $(function() {
 			Entity refEntity = entityList.get(i);
 			String id = propName + i;
 			String liId = "li_" + id;
-			String linkId = propName + "_" + refEntity.getOid();
-			String dispPropLabel = getDisplayPropLabel(editor, refEntity);
-
+			String linkId = "";
+			String linkDisplayStyle = "";
+			String dispPropLabel = "";
 			String key = "";
-			if (length > 0) key = refEntity.getOid() + "_" + refEntity.getVersion();
-
+			// 多重度1で値が未指定の場合の空エンティティは、リンクのIDを指定しない、非表示にする
+			if (refEntity.getOid() != null) {
+				linkId = propName + "_" + refEntity.getOid();
+				dispPropLabel = getDisplayPropLabel(editor, refEntity);
+				key = refEntity.getOid() + "_" + refEntity.getVersion();
+			} else {
+				linkDisplayStyle = "display:none;";
+			}
 %>
 <li id="<c:out value="<%=liId %>"/>" class="list-add unique-list refUnique"
  data-defName="<c:out value="<%=rootDefName%>"/>"
@@ -1405,7 +1411,7 @@ $(function() {
 %>
 </span>
 <span class="unique-ref">
-<a href="javascript:void(0)" class="modal-lnk" id="<c:out value="<%=linkId %>"/>" data-linkId="<c:out value="<%=linkId %>"/>" style="<c:out value="<%=customStyle%>"/>"
+<a href="javascript:void(0)" class="modal-lnk" id="<c:out value="<%=linkId %>"/>" data-linkId="<c:out value="<%=linkId %>"/>" style="<c:out value="<%=linkDisplayStyle%>"/> <c:out value="<%=customStyle%>"/>"
   onclick="<c:out value="<%=showReference %>"/>"><c:out value="<%=dispPropLabel %>" /></a>
 <%
 


### PR DESCRIPTION
## 対応内容

初期表示時に値が未入力の場合は、リンクを非表示にする。
またリンクに付与するIDも空にする （ `null` が指定されないようにする）。

fixes #1952