### PR TITLE
編集画面にReferencePropertyEditorを表示タイプ UNIQUE で配置した場合の不具合修正(3.2)

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
@@ -1200,15 +1200,22 @@ function addUniqueRefItem(ulId, multiplicity, dummyRowId, propName, countId, fun
 		var $link = $("a.modal-lnk", $copy);
 		var $hidden = $(":hidden:last", $copy);
 		var $selBtn = $(":button.sel-btn", $copy);
+		var $insBtn = $(":button.ins-btn", $copy);
 		var $delBtn = $(":button.del-btn", $copy);
 
 		//inputのidを設定
 		$text.attr("id", "uniq_txt_" + copyId);
 
 		if ($("body.modal-body").length != 0) {
+			// modal 内で開く場合
 			$link.subModalWindow();
+			$selBtn.subModalWindow();
+			$insBtn.subModalWindow();
 		} else {
+			// main ページで開く場合
 			$link.modalWindow();
+			$selBtn.modalWindow();
+			$insBtn.modalWindow();
 		}
 
 		//hiddenにnameとidを指定
@@ -4407,6 +4414,12 @@ function addNestRow_Reference(type, cell, idx) {
 		var $li = $(".unique-list", cell);
 		replaceDummyAttr($li, "data-propName", idx);
 		$(".refUnique", cell).refUnique();
+		var $buttons = $(cell).find(".sel-btn, .ins-btn");
+		if ($("body.modal-body").length != 0) {
+			$buttons.subModalWindow();
+		} else {
+			$buttons.modalWindow();
+		}
 	} else if (type == "REFCOMBO") {
 		// 参照コンボの対応
 		$(".ref-combo-sync", cell).refComboSync();

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/functions.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/functions.js
@@ -706,8 +706,7 @@ $.fn.allInputCheck = function(){
 					scriptContext.overlayManager.removeOverlay($overlay);
 				}
 			};
-			$this.off("click.modalWindow")
-				 .on("click.modalWindow", function(){
+			$this.on("click", function(){
 				//ダイアログを起動したものをトリガーとして保持しておき、
 				//maximize,restore,resizeHandlerから呼び出せるようにする。
 				$trigger = $this;
@@ -3136,12 +3135,6 @@ $.fn.allInputCheck = function(){
 			var $link = $("a.modal-lnk", $v);
 			var $hidden = $(":hidden[name='" + $v.propName + "']", $v);
 
-			if ($("body.modal-body").length != 0) {
-				$selBtn.subModalWindow();
-			} else {
-				$selBtn.modalWindow();
-			}
-
 			for (key in params) {
 				$selBtn.attr("data-" + key, params[key]);
 			}
@@ -3151,12 +3144,6 @@ $.fn.allInputCheck = function(){
 				var selDynamicParamCallback = scriptContext[$v.selectDynamicParamCallback];
 				searchUniqueReference($v.attr("id"), $v.selectAction, $v.viewAction, $v.refDefName, $v.propName, $v.selectUrlParam, $v.refEdit, selRefCallback, this, $v.refViewName, $v.permitConditionSelectAll, $v.permitVersionedSelect, $v.defName, $v.viewName, $v.viewType, $v.refSectionIndex, $v.entityOid, $v.entityVersion, selDynamicParamCallback, $v.customStyle);
 			});
-
-			if ($("body.modal-body").length != 0) {
-				$insBtn.subModalWindow();
-			} else {
-				$insBtn.modalWindow();
-			}
 
 			for (key in params) {
 				$insBtn.attr("data-" + key, params[key]);

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/functions.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/functions.js
@@ -706,7 +706,8 @@ $.fn.allInputCheck = function(){
 					scriptContext.overlayManager.removeOverlay($overlay);
 				}
 			};
-			$this.on("click", function(){
+			$this.off("click.modalWindow")
+				 .on("click.modalWindow", function(){
 				//ダイアログを起動したものをトリガーとして保持しておき、
 				//maximize,restore,resizeHandlerから呼び出せるようにする。
 				$trigger = $this;


### PR DESCRIPTION
<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
closes #[1983](https://github.com/dentsusoken/iPLAss/issues/1983)

- 対応：refUnique() から modalWindow() / subModalWindow() の初期化処理を削除し、UNIQUE 参照の業務ロジックのみを担当するように見直しました。
あわせて、動的に追加される UNIQUE 行については [common.js]側で .sel-btn / .ins-btn の modal 初期化を行うように変更し、多重初期化を防ぎつつ追加行でも正しくモーダルが開くようにしました。
## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
