### PR TITLE
GitHub Actions: Javaフォーマットチェックにおいて setup-gradle でキャッシュを改善

### DIFF
--- a/.github/workflows/java-format-check.yml
+++ b/.github/workflows/java-format-check.yml
@@ -18,6 +18,7 @@ jobs:
     name: Java Format Check
     permissions:
       contents: read
+      actions: write
     runs-on: ubuntu-slim
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
@@ -33,10 +34,12 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 21
-          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Run Spotless Check
-        run: ./gradlew spotlessCheck --no-daemon
+        run: ./gradlew spotlessCheck --no-daemon --build-cache --parallel


### PR DESCRIPTION
## 対応内容

Javaフォーマットチェックにおいてsetup-gradle でキャッシュを改善する。

- Build Cacheの利用
- 並列処理の組込

## 動作確認・スクリーンショット（任意）

無し。キャッシュ検証は master マージが必要

## レビュー観点・補足情報（任意）

無し。