### PR TITLE
GEM: 定型検索でカラム以外の式をOrder Byに設定した場合、実行時エラー

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -693,11 +693,11 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 	 * @param propName セットするプロパティ名
 	 * @param nest 参照先Entityのプロパティ
 	 */
-	protected void addSearchProperty(ArrayList<String> select, String propName, NestProperty... nest) {
+	private void addSearchProperty(ArrayList<String> select, String propName, NestProperty... nest) {
 		addSearchProperty(select, propName, null, nest);
 	}
 
-	protected void addSearchProperty(ArrayList<String> select, String propName, PropertyEditor editor, NestProperty... nest) {
+	private void addSearchProperty(ArrayList<String> select, String propName, PropertyEditor editor, NestProperty... nest) {
 		PropertyDefinition pd = getPropertyDefinition(propName);
 		if (pd instanceof ReferenceProperty) {
 			if (!select.contains(propName + "." + Entity.NAME)) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -59,6 +59,7 @@ import org.iplass.mtp.entity.query.SortSpec;
 import org.iplass.mtp.entity.query.SortSpec.NullOrderingSpec;
 import org.iplass.mtp.entity.query.SortSpec.SortType;
 import org.iplass.mtp.entity.query.condition.Condition;
+import org.iplass.mtp.entity.query.value.ValueExpression;
 import org.iplass.mtp.entity.query.value.primary.EntityField;
 import org.iplass.mtp.entity.query.value.primary.Literal;
 import org.iplass.mtp.impl.parser.ParseContext;
@@ -190,20 +191,20 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 				}
 			}
 		}
+		List<EntityField> fieldSelection = select.stream()
+				.map(EntityField::new)
+				.toList();
+		List<ValueExpression> orderBySelection = Optional.ofNullable(getOrderBy())
+				.stream()
+				.flatMap(orderBy -> orderBy.getSortSpecList()
+						.stream()
+						.map(SortSpec::getSortKey))
+				.toList();
+
 		// ソート条件のデータを取得カラムにしておかないと、DistinctでSQLエラーになる。
-		OrderBy orderBy = getOrderBy();
-		if (orderBy != null) {
-			for (SortSpec sortSpec : orderBy.getSortSpecList()) {
-				String sortKey = sortSpec.getSortKey()
-						.toString();
-				if (!select.contains(sortKey))
-					addSearchProperty(select, sortKey);
-			}
-		}
-		boolean distinct = getConditionSection().isDistinct();
-		Select s = new Select().add(select.toArray());
-		s.setDistinct(distinct);
-		return s;
+		return new Select(getConditionSection().isDistinct(), Stream.concat(fieldSelection.stream(), orderBySelection.stream())
+				.distinct()
+				.toList());
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -191,8 +191,8 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 				}
 			}
 		}
-		List<EntityField> fieldSelection = select.stream()
-				.map(EntityField::new)
+		List<ValueExpression> fieldSelection = select.stream()
+				.<ValueExpression> map(EntityField::new)
 				.toList();
 		List<ValueExpression> orderBySelection = Optional.ofNullable(getOrderBy())
 				.stream()
@@ -202,7 +202,8 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 				.toList();
 
 		// ソート条件のデータを取得カラムにしておかないと、DistinctでSQLエラーになる。
-		return new Select(getConditionSection().isDistinct(), Stream.concat(fieldSelection.stream(), orderBySelection.stream())
+		boolean isDistinct = getConditionSection().isDistinct();
+		return new Select(isDistinct, (isDistinct ? Stream.concat(fieldSelection.stream(), orderBySelection.stream()) : fieldSelection.stream())
 				.distinct()
 				.toList());
 	}

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -693,11 +693,11 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 	 * @param propName セットするプロパティ名
 	 * @param nest 参照先Entityのプロパティ
 	 */
-	private void addSearchProperty(ArrayList<String> select, String propName, NestProperty... nest) {
+	protected void addSearchProperty(ArrayList<String> select, String propName, NestProperty... nest) {
 		addSearchProperty(select, propName, null, nest);
 	}
 
-	private void addSearchProperty(ArrayList<String> select, String propName, PropertyEditor editor, NestProperty... nest) {
+	protected void addSearchProperty(ArrayList<String> select, String propName, PropertyEditor editor, NestProperty... nest) {
 		PropertyDefinition pd = getPropertyDefinition(propName);
 		if (pd instanceof ReferenceProperty) {
 			if (!select.contains(propName + "." + Entity.NAME)) {

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchSelectListContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchSelectListContext.java
@@ -44,6 +44,7 @@ import org.iplass.mtp.view.generic.SearchFormView;
 import org.iplass.mtp.view.generic.SearchQueryContext;
 import org.iplass.mtp.view.generic.SearchQueryInterrupter;
 import org.iplass.mtp.view.generic.SearchQueryInterrupter.SearchQueryType;
+import org.iplass.mtp.view.generic.editor.NestProperty;
 import org.iplass.mtp.view.generic.element.property.PropertyColumn;
 import org.iplass.mtp.view.generic.element.property.PropertyItem;
 import org.iplass.mtp.view.generic.element.section.SearchConditionSection;
@@ -205,6 +206,11 @@ public class SearchSelectListContext extends SearchContextBase {
 	@Override
 	protected Integer getOffset() {
 		return context.getOffset();
+	}
+
+	@Override
+	protected void addSearchProperty(ArrayList<String> select, String propName, NestProperty... nest) {
+		context.addSearchProperty(select, propName, nest);
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchSelectListContext.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchSelectListContext.java
@@ -44,7 +44,6 @@ import org.iplass.mtp.view.generic.SearchFormView;
 import org.iplass.mtp.view.generic.SearchQueryContext;
 import org.iplass.mtp.view.generic.SearchQueryInterrupter;
 import org.iplass.mtp.view.generic.SearchQueryInterrupter.SearchQueryType;
-import org.iplass.mtp.view.generic.editor.NestProperty;
 import org.iplass.mtp.view.generic.element.property.PropertyColumn;
 import org.iplass.mtp.view.generic.element.property.PropertyItem;
 import org.iplass.mtp.view.generic.element.section.SearchConditionSection;
@@ -206,11 +205,6 @@ public class SearchSelectListContext extends SearchContextBase {
 	@Override
 	protected Integer getOffset() {
 		return context.getOffset();
-	}
-
-	@Override
-	protected void addSearchProperty(ArrayList<String> select, String propName, NestProperty... nest) {
-		context.addSearchProperty(select, propName, nest);
 	}
 
 	@Override


### PR DESCRIPTION


## 対応内容

closes #1960

## 動作確認・スクリーンショット（任意）


以下の条件分岐を網羅して動作確認(結果が正常に返る/ソート成功)した。
- 重複行排除あり / 無し
- 単純にカラム指定 / 以外の式

<img width="2297" height="1144" alt="2026-04-22_14h37_48" src="https://github.com/user-attachments/assets/aada7eb6-57c6-4023-9bc8-d011f25b2253" />

## レビュー観点・補足情報（任意）
