### PR TITLE
GEM: 定型検索でカラム以外の式をOrder Byに設定した場合、実行時エラー（3.2）

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -54,6 +54,8 @@ import org.iplass.mtp.entity.query.SortSpec;
 import org.iplass.mtp.entity.query.SortSpec.NullOrderingSpec;
 import org.iplass.mtp.entity.query.SortSpec.SortType;
 import org.iplass.mtp.entity.query.condition.Condition;
+import org.iplass.mtp.entity.query.value.ValueExpression;
+import org.iplass.mtp.entity.query.value.primary.EntityField;
 import org.iplass.mtp.entity.query.value.primary.Literal;
 import org.iplass.mtp.impl.util.ObjectUtil;
 import org.iplass.mtp.util.StringUtil;
@@ -177,18 +179,21 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 				}
 			}
 		}
+		List<ValueExpression> fieldSelection = select.stream()
+				.<ValueExpression> map(EntityField::new)
+				.toList();
+		List<ValueExpression> orderBySelection = Optional.ofNullable(getOrderBy())
+				.stream()
+				.flatMap(orderBy -> orderBy.getSortSpecList()
+						.stream()
+						.map(SortSpec::getSortKey))
+				.toList();
+
 		// ソート条件のデータを取得カラムにしておかないと、DistinctでSQLエラーになる。
-		OrderBy orderBy = getOrderBy();
-		if (orderBy != null) {
-			for (SortSpec sortSpec : orderBy.getSortSpecList()) {
-				String sortKey = sortSpec.getSortKey().toString();
-				if (!select.contains(sortKey)) addSearchProperty(select, sortKey);
-			}
-		}
-		boolean distinct = getConditionSection().isDistinct();
-		Select s = new Select().add(select.toArray());
-		s.setDistinct(distinct);
-		return s;
+		boolean isDistinct = getConditionSection().isDistinct();
+		return new Select(isDistinct, (isDistinct ? Stream.concat(fieldSelection.stream(), orderBySelection.stream()) : fieldSelection.stream())
+				.distinct()
+				.toList());
 	}
 
 	@Override

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.iplass.gem.command.CommandUtil;
 import org.iplass.gem.command.Constants;

--- a/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
+++ b/iplass-gem/src/main/java/org/iplass/gem/command/generic/search/SearchContextBase.java
@@ -182,19 +182,19 @@ public abstract class SearchContextBase implements SearchContext, CreateSearchRe
 		}
 		List<ValueExpression> fieldSelection = select.stream()
 				.<ValueExpression> map(EntityField::new)
-				.toList();
+				.collect(Collectors.toList());
 		List<ValueExpression> orderBySelection = Optional.ofNullable(getOrderBy())
 				.stream()
 				.flatMap(orderBy -> orderBy.getSortSpecList()
 						.stream()
 						.map(SortSpec::getSortKey))
-				.toList();
+				.collect(Collectors.toList());
 
 		// ソート条件のデータを取得カラムにしておかないと、DistinctでSQLエラーになる。
 		boolean isDistinct = getConditionSection().isDistinct();
 		return new Select(isDistinct, (isDistinct ? Stream.concat(fieldSelection.stream(), orderBySelection.stream()) : fieldSelection.stream())
 				.distinct()
-				.toList());
+				.collect(Collectors.toList()));
 	}
 
 	@Override


### PR DESCRIPTION


## 対応内容

closes #2044

#2039 をcherry-pick した

## 動作確認・スクリーンショット（任意）

#2039 と同じ動作確認を行った

## レビュー観点・補足情報（任意）
