### PR TITLE
GEM: NumberPropertyEditorにおいて、最大文字数の設定が反映されない

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaNumberPropertyEditor.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/generic/editor/MetaNumberPropertyEditor.java
@@ -284,6 +284,7 @@ public abstract class MetaNumberPropertyEditor extends MetaPrimitivePropertyEdit
 		pe.setHideSearchConditionFrom(hideSearchConditionFrom);
 		pe.setHideSearchConditionTo(hideSearchConditionTo);
 		pe.setHideSearchConditionRangeSymbol(hideSearchConditionRangeSymbol);
+		pe.setMaxlength(maxlength);
 		pe.setInsertWithLabelValue(insertWithLabelValue);
 		pe.setUpdateWithLabelValue(updateWithLabelValue);
 	}


### PR DESCRIPTION

## 対応内容
最大桁数を指定する記述を追加
closes #1882 

## 動作確認・スクリーンショット（任意）

## レビュー観点・補足情報（任意）
