### PR TITLE
GEM: ファイルアップロード画面 vs ウィジェットで、検索Formデータが混線する

### DIFF
--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
@@ -395,7 +395,10 @@ public class MetaEntityListParts extends MetaTemplateParts {
 				request.removeAttribute("entityListParts");
 				request.removeAttribute("listPartsSearchFormView");
 				request.removeAttribute("title");
-				request.removeAttribute("partsCnt");
+				// partsCnt は削除NG（∵ 呼び出し元 TopViewHandler.loadParts() がHttpServletRequest 経由で参照するため）
+				// TODO: とは言え、この対応はその場しのぎに見える（∵ clearAttribute() の本来の責務は setAttribute() でセットした属性のクリーンアップのはず）
+				// 使われる側が呼び出し元の実装に依存するのは、設計上好ましくない
+				// partsCnt を管理する責務を負うのは HttpServletRequest？RequestContext？設計が曖昧では？
 			}
 
 			private boolean checkEntity() {

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
@@ -384,7 +384,7 @@ public class MetaEntityListParts extends MetaTemplateParts {
 					}
 				}
 
-				request.setAttribute("entityListParts", currentConfig());
+				request.setAttribute("MetaEntityListParts_entityListParts", currentConfig());
 				request.setAttribute("MetaEntityListParts_searchFormView", form);
 				request.setAttribute("MetaEntityListParts_title", title);
 			}
@@ -392,7 +392,7 @@ public class MetaEntityListParts extends MetaTemplateParts {
 			@Override
 			public void clearAttribute(HttpServletRequest req) {
 				RequestContext request = WebUtil.getRequestContext();
-				request.removeAttribute("entityListParts");
+				request.removeAttribute("MetaEntityListParts_entityListParts");
 				request.removeAttribute("MetaEntityListParts_searchFormView");
 				request.removeAttribute("MetaEntityListParts_title");
 				// partsCnt は削除NG（∵ 呼び出し元 TopViewHandler.loadParts() がHttpServletRequest 経由で参照するため）

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
@@ -385,16 +385,16 @@ public class MetaEntityListParts extends MetaTemplateParts {
 				}
 
 				request.setAttribute("entityListParts", currentConfig());
-				request.setAttribute("listPartsSearchFormView", form);
-				request.setAttribute("title", title);
+				request.setAttribute("MetaEntityListParts_searchFormView", form);
+				request.setAttribute("MetaEntityListParts_title", title);
 			}
 
 			@Override
 			public void clearAttribute(HttpServletRequest req) {
 				RequestContext request = WebUtil.getRequestContext();
 				request.removeAttribute("entityListParts");
-				request.removeAttribute("listPartsSearchFormView");
-				request.removeAttribute("title");
+				request.removeAttribute("MetaEntityListParts_searchFormView");
+				request.removeAttribute("MetaEntityListParts_title");
 				// partsCnt は削除NG（∵ 呼び出し元 TopViewHandler.loadParts() がHttpServletRequest 経由で参照するため）
 				// TODO: とは言え、この対応は「その場しのぎ」に見える（∵ clearAttribute() の本来の責務は setAttribute() でセットした属性のクリーンアップのはず）
 				// 使われる側が呼び出し元の実装に依存するのは、設計上好ましくない

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
@@ -396,9 +396,9 @@ public class MetaEntityListParts extends MetaTemplateParts {
 				request.removeAttribute("listPartsSearchFormView");
 				request.removeAttribute("title");
 				// partsCnt は削除NG（∵ 呼び出し元 TopViewHandler.loadParts() がHttpServletRequest 経由で参照するため）
-				// TODO: とは言え、この対応はその場しのぎに見える（∵ clearAttribute() の本来の責務は setAttribute() でセットした属性のクリーンアップのはず）
+				// TODO: とは言え、この対応は「その場しのぎ」に見える（∵ clearAttribute() の本来の責務は setAttribute() でセットした属性のクリーンアップのはず）
 				// 使われる側が呼び出し元の実装に依存するのは、設計上好ましくない
-				// partsCnt を管理する責務を負うのは HttpServletRequest？RequestContext？設計が曖昧では？
+				// partsCnt を管理する責務を負うのは HttpServletRequest？RequestContext？設計が曖昧な可能性あり
 			}
 
 			private boolean checkEntity() {

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
@@ -391,6 +391,11 @@ public class MetaEntityListParts extends MetaTemplateParts {
 
 			@Override
 			public void clearAttribute(HttpServletRequest req) {
+				RequestContext request = WebUtil.getRequestContext();
+				request.removeAttribute("entityListParts");
+				request.removeAttribute("listPartsSearchFormView");
+				request.removeAttribute("title");
+				request.removeAttribute("partsCnt");
 			}
 
 			private boolean checkEntity() {

--- a/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
+++ b/iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts/MetaEntityListParts.java
@@ -385,7 +385,7 @@ public class MetaEntityListParts extends MetaTemplateParts {
 				}
 
 				request.setAttribute("entityListParts", currentConfig());
-				request.setAttribute("searchFormView", form);
+				request.setAttribute("listPartsSearchFormView", form);
 				request.setAttribute("title", title);
 			}
 

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
@@ -62,7 +62,7 @@
 	EntityListParts parts = (EntityListParts) request.getAttribute("entityListParts");
 	if (parts == null) return;
 
-	SearchFormView form = (SearchFormView) request.getAttribute("searchFormView");
+	SearchFormView form = (SearchFormView) request.getAttribute("listPartsSearchFormView");
 
 	String topViewListOffsetInfo = request.getParameter(Constants.TOPVIEW_LIST_OFFSET);
 

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
@@ -62,7 +62,7 @@
 	EntityListParts parts = (EntityListParts) request.getAttribute("entityListParts");
 	if (parts == null) return;
 
-	SearchFormView form = (SearchFormView) request.getAttribute("listPartsSearchFormView");
+	SearchFormView form = (SearchFormView) request.getAttribute("MetaEntityListParts_searchFormView");
 
 	String topViewListOffsetInfo = request.getParameter(Constants.TOPVIEW_LIST_OFFSET);
 
@@ -144,7 +144,7 @@
 <div class="<c:out value="<%=cellStyle %>"/>" id="topview-parts-id_${partsCnt}" style="display:none;">
 <h3 class="hgroup-02">
 ${entityListParts.iconTag}
-${m:esc(title)}
+${m:esc(MetaEntityListParts_title)}
 </h3>
 <%
 	String id = ((int)(Math.random() * 1000) + "_" + new Date().getTime());

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/list.jsp
@@ -59,7 +59,7 @@
 	}
 %>
 <%
-	EntityListParts parts = (EntityListParts) request.getAttribute("entityListParts");
+	EntityListParts parts = (EntityListParts) request.getAttribute("MetaEntityListParts_entityListParts");
 	if (parts == null) return;
 
 	SearchFormView form = (SearchFormView) request.getAttribute("MetaEntityListParts_searchFormView");
@@ -143,7 +143,7 @@
 %>
 <div class="<c:out value="<%=cellStyle %>"/>" id="topview-parts-id_${partsCnt}" style="display:none;">
 <h3 class="hgroup-02">
-${entityListParts.iconTag}
+${MetaEntityListParts_entityListParts.iconTag}
 ${m:esc(MetaEntityListParts_title)}
 </h3>
 <%
@@ -429,7 +429,7 @@ colModel.push({name:"<%=propName%>", index:"<%=propName%>", classes:"<%=style%>"
 
 		var sortKey = $table.attr("data-sortKey");
 		var sortType = $table.attr("data-sortType");
-		searchEntityList("<%=SearchListCommand.WEBAPI_NAME%>", "${m:escJs(entityListParts.defName)}", "${m:escJs(entityListParts.viewName)}", "${m:escJs(entityListParts.filterName)}", offset, sortKey, sortType, "<%=searchAsync%>", function(list) {
+		searchEntityList("<%=SearchListCommand.WEBAPI_NAME%>", "${m:escJs(MetaEntityListParts_entityListParts.defName)}", "${m:escJs(MetaEntityListParts_entityListParts.viewName)}", "${m:escJs(MetaEntityListParts_entityListParts.filterName)}", offset, sortKey, sortType, "<%=searchAsync%>", function(list) {
 			$pager.setPage(offset, list.length, null);
 			// listのサイズを表示件数設定に従い補正
 			if (list.length > limit) {

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/listWidget.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/listWidget.jsp
@@ -41,7 +41,7 @@
 	EntityListParts parts = (EntityListParts) request.getAttribute("entityListParts");
 	if (parts == null) return;
 
-	SearchFormView form = (SearchFormView) request.getAttribute("listPartsSearchFormView");
+	SearchFormView form = (SearchFormView) request.getAttribute("MetaEntityListParts_searchFormView");
 
 	String urlPath = ViewUtil.getParamMappingPath(parts.getDefName(), parts.getViewNameForLink());
 	String searchViewAction = SearchViewCommand.SEARCH_ACTION_NAME + urlPath;
@@ -74,7 +74,7 @@
  data-limit="<%=limit%>" data-prevLabel="<c:out value="<%=prevLabel%>"/>" data-nextLabel="<c:out value="<%=nextLabel%>"/>">
 <div class="lyt-shortcut-01 mb05">
 ${entityListParts.iconTag}
-<p class="title">${m:esc(title)}</p>
+<p class="title">${m:esc(MetaEntityListParts_title)}</p>
 <div class="widget-contents" style="<%=styleAttr%>">
 <ul class="list-entity-name" data-webapiName="<%=SearchNameListCommand.WEBAPI_NAME%>" data-viewAction="<c:out value="<%=viewAction%>" />">
 </ul>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/listWidget.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/listWidget.jsp
@@ -38,7 +38,7 @@
 <%@ page import="org.iplass.gem.command.ViewUtil"%>
 <%
 	String contextPath = TemplateUtil.getStaticContentPath();
-	EntityListParts parts = (EntityListParts) request.getAttribute("entityListParts");
+	EntityListParts parts = (EntityListParts) request.getAttribute("MetaEntityListParts_entityListParts");
 	if (parts == null) return;
 
 	SearchFormView form = (SearchFormView) request.getAttribute("MetaEntityListParts_searchFormView");
@@ -70,10 +70,10 @@
 	//パーツの高さスタイル属性
 	String styleAttr = ViewUtil.buildHeightStyleAttr(parts.getMaxHeight());
 %>
-<div class="<c:out value="<%=style %>"/>" data-defName="${m:escJs(entityListParts.defName)}" data-viewName="${m:escJs(entityListParts.viewName)}" data-filterName="${m:escJs(entityListParts.filterName)}"
+<div class="<c:out value="<%=style %>"/>" data-defName="${m:escJs(MetaEntityListParts_entityListParts.defName)}" data-viewName="${m:escJs(MetaEntityListParts_entityListParts.viewName)}" data-filterName="${m:escJs(MetaEntityListParts_entityListParts.filterName)}"
  data-limit="<%=limit%>" data-prevLabel="<c:out value="<%=prevLabel%>"/>" data-nextLabel="<c:out value="<%=nextLabel%>"/>">
 <div class="lyt-shortcut-01 mb05">
-${entityListParts.iconTag}
+${MetaEntityListParts_entityListParts.iconTag}
 <p class="title">${m:esc(MetaEntityListParts_title)}</p>
 <div class="widget-contents" style="<%=styleAttr%>">
 <ul class="list-entity-name" data-webapiName="<%=SearchNameListCommand.WEBAPI_NAME%>" data-viewAction="<c:out value="<%=viewAction%>" />">

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/listWidget.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/search/listWidget.jsp
@@ -41,7 +41,7 @@
 	EntityListParts parts = (EntityListParts) request.getAttribute("entityListParts");
 	if (parts == null) return;
 
-	SearchFormView form = (SearchFormView) request.getAttribute("searchFormView");
+	SearchFormView form = (SearchFormView) request.getAttribute("listPartsSearchFormView");
 
 	String urlPath = ViewUtil.getParamMappingPath(parts.getDefName(), parts.getViewNameForLink());
 	String searchViewAction = SearchViewCommand.SEARCH_ACTION_NAME + urlPath;


### PR DESCRIPTION

# 対応内容

closes #1976 

## バグ原因

ファイルアップロード画面のSearchFormViewデータが、Widget画面処理で**別データで上書き**されていた

## 修正内容

上書きしないように（キーを変更。重複しないように）


# 動作確認・スクリーンショット（任意）

## メイン修正

<img width="2382" height="872" alt="2026-05-20_20h55_22" src="https://github.com/user-attachments/assets/91784b24-35cf-4626-95ff-0d37ee29c62e" />


## デグレチェック

Widget以外の画面にデグレがないことを確認した
- Top画面 > EntityListParts 


# レビュー観点・補足情報（任意）

## 横展開チェック

`iplass-gem/src/main/java/org/iplass/mtp/impl/view/top/parts`
の中で、今回の問題（以下）と同じ実装がないか、横展開チェックした
- キー衝突
- セットしたのにクリアしてない

→ 問題なし
