### PR TITLE
GEM: 検索条件のReferencePropertyEditorが表示タイプ「UNIQUE」かつ多重度=1の場合、削除ボタンが動作しない修正（3.2）

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Condition.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Condition.jsp
@@ -1120,8 +1120,9 @@ $(function() {
 					+ ", '" + StringUtil.escapeJavaScript(linkId) + "'"
 					+ ", false"
 					+ ")";
-				String deleteItem = "deleteItem(" 
-					+ "'" + StringUtil.escapeJavaScript(liId) + "'" 
+				String deleteItem = "deleteUniqueRefItem(" 
+					+ "'" + StringUtil.escapeJavaScript(liId) + "'"
+					+ ", " + isMultiple
 					+ ")";
 %>
 <li id="<c:out value="<%=liId %>"/>" class="list-add unique-list refUnique"
@@ -1184,8 +1185,9 @@ $(function() {
 					+ ", '" + StringUtil.escapeJavaScript(linkId) + "'"
 					+ ", false"
 					+ ")";
-				String deleteItem = "deleteItem(" 
+				String deleteItem = "deleteUniqueRefItem(" 
 					+ "'" + StringUtil.escapeJavaScript(liId) + "'" 
+					+ ", " + isMultiple
 					+ ")";
 %>
 <li id="<c:out value="<%=liId %>"/>" class="list-add unique-list refUnique"
@@ -1227,6 +1229,11 @@ $(function() {
 
 		if (length == 0) {
 			String liId = "li_" + propName + "0";
+
+			String deleteItem = "deleteUniqueRefItem(" 
+				+ "'" + StringUtil.escapeJavaScript(liId) + "'" 
+				+ ", " + isMultiple
+				+ ")";
 %>
 <li id="<c:out value="<%=liId %>"/>" class="list-add unique-list refUnique"
  data-defName="<c:out value="<%=rootDefName%>"/>"
@@ -1254,21 +1261,8 @@ $(function() {
 </span>
 <span class="unique-ref">
 <a href="javascript:void(0)" class="modal-lnk" style="<c:out value="<%=customStyle%>"/>"></a>
-<%
-			if (isMultiple) {
-				String deleteItem = "deleteItem(" 
-					+ "'" + StringUtil.escapeJavaScript(liId) + "'" 
-					+ ")";
-%>
 <input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_Edit.delete')}" class="gr-btn-02 del-btn"
  onclick="<c:out value="<%=deleteItem %>"/>"/>
-<%
-			} else {
-%>
-<input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_Edit.delete')}" class="gr-btn-02 del-btn"/>
-<%
-			}
-%>
 </span>
 <input type="hidden" id="i_<c:out value="<%=liId%>"/>" name="<c:out value="<%=propName %>"/>" value=""/>
 </li>

--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/editor/reference/ReferencePropertyEditor_Edit.jsp
@@ -1417,30 +1417,15 @@ $(function() {
 
 			if (!hideDeleteButton && updatable) {
 
-				if (isMultiple) {
-					String deleteItem = "deleteItem(" 
-						+ "'" + StringUtil.escapeJavaScript(liId) + "'" 
-						+ ", " + toggleAddBtnFunc
-						+ ")";
+				String deleteItem = "deleteUniqueRefItem(" 
+					+ "'" + StringUtil.escapeJavaScript(liId) + "'" 
+					+ ", " + isMultiple
+					+ ", " + (isMultiple ? toggleAddBtnFunc : null)
+					+ ")";
 %>
 <input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_Edit.delete')}" class="gr-btn-02 del-btn"
  onclick="<c:out value="<%=deleteItem %>"/>"/>
 <%
-				} else {
-					// 多重度が1の場合は、削除ではなく値をクリアする
-					String clearUniqueRefFunc = "clearUniqueBtn_" + StringUtil.escapeJavaScript(propName);
-%>
-<script type="text/javascript">
-function <%=clearUniqueRefFunc%>() {
-	const $txt = $("#uniq_txt_" + es("<%=StringUtil.escapeJavaScript(liId)%>"));
-	$txt.val("");
-	$txt.change();
-}
-</script>
-<input type="button" value="${m:rs('mtp-gem-messages', 'generic.editor.reference.ReferencePropertyEditor_Edit.delete')}" class="gr-btn-02 del-btn"
- onclick="<c:out value="<%=clearUniqueRefFunc %>"/>()"/>
-<%
-				}
 			}
 %>
 </span>

--- a/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
+++ b/iplass-gem/src/main/resources/META-INF/resources/scripts/gem/common.js
@@ -1169,6 +1169,25 @@ function addDateItem(ulId, multiplicity, dummyRowId, propName, countId, func, de
 }
 
 /**
+ * 検索画面、編集画面 参照プロパティ ユニーク項目削除
+ *
+ * @param liId 参照アイテムのID
+ * @param isMultiple 多重度複数を許可するか
+ * @param delCallback 削除時のCallback
+ */
+function deleteUniqueRefItem(liId, isMultiple, delCallback) {
+	if (isMultiple) {
+		// 多重度が複数の場合はアイテムを削除
+		deleteItem(liId, delCallback);
+	} else {
+		// 多重度が1の場合は値をクリア
+		const $txt = $("#uniq_txt_" + es(liId));
+		$txt.val("");
+		$txt.change();
+	}
+}
+
+/**
  * 参照画面 ユニーク項目追加
  *
  * @param ulId
@@ -1224,8 +1243,8 @@ function addUniqueRefItem(ulId, multiplicity, dummyRowId, propName, countId, fun
 
 		//selectボタンにidを設定
 		$selBtn.attr("id", "sel_btn_" + newId);
-		//削除ボタンのclickを設定
-		$delBtn.click(function() {deleteItem(copyId, delCallback);});
+		//削除ボタンのclickを設定(追加可能なので多重度複数)
+		$delBtn.click(function() {deleteUniqueRefItem(copyId, true, delCallback);});
 
 		$copy.css("display", "");
 		$copy.refUnique();


### PR DESCRIPTION
## 対応内容

- 多重度1の場合は、入力エリアを削除せず保持している値をクリアする。
- #1885 で対応した編集画面と処理を共通化する。

fixes #1986

## 動作確認・スクリーンショット

1. 検索画面、検索条件

- 参照プロパティの多重度に関係なく、設定で「Unique」かつ「検索条件で単一選択= true 」として多重度1の状態にする。
- その上で、削除した時に、項目は削除されずに、値がクリアされること。
- 「検索条件で単一選択= false」の場合は、項目を追加、削除することができること。

2. 編集画面

- 多重度1の参照プロパティに対して、設定で「Unique」指定する。
- その上で、削除した時に、項目は削除されずに、値がクリアされること。
- 多重度が複数の場合は、項目を追加、削除することができること。
