### PR TITLE
AccessToken, RefreshToken に Serializable を実装（3.2）

### DIFF
--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/AccessToken.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/AccessToken.java
@@ -19,11 +19,19 @@
  */
 package org.iplass.mtp.impl.auth.oauth.token;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.iplass.mtp.auth.User;
 
-public abstract class AccessToken {
+/**
+ * AccessToken
+ *
+ * @author DENTSU SOKEN INC.
+ */
+public abstract class AccessToken implements Serializable {
+	/** SerialVersionUID */
+	private static final long serialVersionUID = -5246481800150962189L;
 	
 	public abstract RefreshToken getRefreshToken();
 	public abstract List<String> getGrantedScopes();

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/RefreshToken.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/RefreshToken.java
@@ -19,7 +19,16 @@
  */
 package org.iplass.mtp.impl.auth.oauth.token;
 
-public abstract class RefreshToken {
+import java.io.Serializable;
+
+/**
+ * RefreshToken
+ *
+ * @author DENTSU SOKEN INC.
+ */
+public abstract class RefreshToken implements Serializable {
+	/** SerialVersionUID */
+	private static final long serialVersionUID = 6799651154697085030L;
 	
 	public abstract String getTokenEncoded();
 	public abstract long getExpiresIn();

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/opaque/OpaqueAccessToken.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/opaque/OpaqueAccessToken.java
@@ -29,7 +29,14 @@ import org.iplass.mtp.impl.auth.oauth.MetaOAuthClient.OAuthClientRuntime;
 import org.iplass.mtp.impl.auth.oauth.token.AccessToken;
 import org.iplass.mtp.impl.auth.oauth.token.RefreshToken;
 
+/**
+ * OpaqueAccessToken
+ *
+ * @author DENTSU SOKEN INC.
+ */
 public class OpaqueAccessToken extends AccessToken {
+	/** SerialVersionUID */
+	private static final long serialVersionUID = 6843788849936194079L;
 	
 	private String series;
 	private String tokenEncoded;

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/opaque/OpaqueRefreshToken.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/opaque/OpaqueRefreshToken.java
@@ -22,7 +22,14 @@ package org.iplass.mtp.impl.auth.oauth.token.opaque;
 import org.iplass.mtp.impl.auth.oauth.MetaOAuthClient.OAuthClientRuntime;
 import org.iplass.mtp.impl.auth.oauth.token.RefreshToken;
 
+/**
+ * OpaqueRefreshToken
+ *
+ * @author DENTSU SOKEN INC.
+ */
 public class OpaqueRefreshToken extends RefreshToken {
+	/** SerialVersionUID */
+	private static final long serialVersionUID = -7991698445157501978L;
 	
 	private String series;
 	private String tokenEncoded;

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/remote/RemoteAccessToken.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/token/remote/RemoteAccessToken.java
@@ -26,7 +26,14 @@ import org.iplass.mtp.auth.User;
 import org.iplass.mtp.impl.auth.oauth.token.AccessToken;
 import org.iplass.mtp.impl.auth.oauth.token.RefreshToken;
 
+/**
+ * RemoteAccessToken
+ *
+ * @author DENTSU SOKEN INC.
+ */
 public class RemoteAccessToken extends AccessToken {
+	/** SerialVersionUID */
+	private static final long serialVersionUID = 5425823644475667735L;
 	
 	private String tokenEncoded;
 	private User user;


### PR DESCRIPTION
closes #2083 

<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
- AccessToken, RefreshToken に Serializable を実装
- 派生クラスの RemoteAccessToken, OpaqueAccessToken, OpaqueRefreshToken に serialVersionUID を実装

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
- OAuth を利用し WebApi を実行

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
