### PR TITLE
Web: BearerToken取得対象の拡張

### DIFF
--- a/iplass-core/src/main/java/org/iplass/mtp/auth/login/TokenCredential.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/auth/login/TokenCredential.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.auth.login;
+
+/**
+ * <% if (doclang == "ja") {%>
+ * トークンベース認証インターフェース
+ * <% } else { %>
+ * Token-based authentication interface
+ * <% } %>
+ *
+ * @author SEKIGUCHI Naoya
+ */
+public interface TokenCredential extends Credential {
+	/**
+	 * <% if (doclang == "ja") {%>
+	 * トークンを取得します。
+	 * <% } else { %>
+	 * Gets the token.
+	 * <% } %>
+	 * @return <% if (doclang == "ja") {%> トークン <% } else { %> the token <% } %>
+	 */
+	String getToken();
+}

--- a/iplass-core/src/main/java/org/iplass/mtp/auth/login/token/SimpleAuthTokenCredential.java
+++ b/iplass-core/src/main/java/org/iplass/mtp/auth/login/token/SimpleAuthTokenCredential.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2018 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.iplass.mtp.auth.login.Credential;
+import org.iplass.mtp.auth.login.TokenCredential;
 
 /**
  * シンプルな認証トークンで認証する際のCredentialです。
@@ -31,11 +31,11 @@ import org.iplass.mtp.auth.login.Credential;
  * 認証トークンは事前にAuthTokenInfoListにて生成する必要があります。
  * SimpleAuthTokenは、当該トークンが紐付くユーザーとしてのアクセスを許可します。
  * また、SimpleAuthTokenは明示的に削除されるまで、永続的に有効です。
- * 
+ *
  * @author K.Higuchi
  *
  */
-public class SimpleAuthTokenCredential implements Credential, Serializable {
+public class SimpleAuthTokenCredential implements TokenCredential, Serializable {
 	private static final long serialVersionUID = -5890942191793851280L;
 
 	private String id;
@@ -59,6 +59,7 @@ public class SimpleAuthTokenCredential implements Credential, Serializable {
 		return id;
 	}
 
+	@Override
 	public String getToken() {
 		return token;
 	}
@@ -78,7 +79,7 @@ public class SimpleAuthTokenCredential implements Credential, Serializable {
 	@Override
 	public void setAuthenticationFactor(String name, Object value) {
 		if (additionalAuthenticationFactor == null) {
-			additionalAuthenticationFactor = new HashMap<String, Object>();
+			additionalAuthenticationFactor = new HashMap<>();
 		}
 		additionalAuthenticationFactor.put(name, value);
 	}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
@@ -96,7 +96,14 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 		if (bearerTokenHeaderOnly) {
 			return false;
 		}
-		if (!"application/x-www-form-urlencoded".equals(tokenSupplier.getContentType())) {
+
+		var contentType = tokenSupplier.getContentType();
+		if (contentType == null) {
+			return false;
+		}
+		// application/x-www-form-urlencoded; charset=UTF-8 のように、セミコロンで区切られた場合があるため、区切った最初の部分を検査する。
+		var baseContentType = contentType.split(";", 2)[0].trim();
+		if (!"application/x-www-form-urlencoded".equals(baseContentType)) {
 			return false;
 		}
 		if (tokenSupplier.methodType() == null || tokenSupplier.methodType() == MethodType.GET) {//reject DELETE?
@@ -162,7 +169,7 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 			} else {
 				AuthToken token = new AuthToken(tokenStr);
 				logger.warn("login session is avaliable, but another bearer token is specified. currentUser:" + user.getAccount()
-						.getUnmodifiableUniqueKey() + ", token:" + token.getType() + "." + token.getSeries() + "...");
+				.getUnmodifiableUniqueKey() + ", token:" + token.getType() + "." + token.getSeries() + "...");
 			}
 
 			return AutoLoginInstruction.THROUGH;

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2018 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -21,7 +21,7 @@ package org.iplass.mtp.impl.auth.authenticate.token.web;
 
 import org.iplass.mtp.ApplicationException;
 import org.iplass.mtp.auth.login.Credential;
-import org.iplass.mtp.auth.login.token.SimpleAuthTokenCredential;
+import org.iplass.mtp.auth.login.TokenCredential;
 import org.iplass.mtp.command.RequestContext;
 import org.iplass.mtp.impl.auth.UserContext;
 import org.iplass.mtp.impl.auth.authenticate.AutoLoginHandler;
@@ -31,18 +31,14 @@ import org.iplass.mtp.impl.auth.authenticate.token.AuthTokenHandler;
 import org.iplass.mtp.impl.auth.authenticate.token.AuthTokenService;
 import org.iplass.mtp.impl.session.Session;
 import org.iplass.mtp.impl.session.SessionService;
-import org.iplass.mtp.impl.webapi.rest.RestRequestContext;
 import org.iplass.mtp.spi.ServiceRegistry;
-import org.iplass.mtp.web.WebRequestConstants;
 import org.iplass.mtp.webapi.definition.MethodType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 /**
  * RFC6750ベースのAutoLoginHandler。
- * 
+ *
  * @author K.Higuchi
  *
  */
@@ -95,35 +91,35 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 		this.authTokenHandler = authTokenHandler;
 	}
 
-	private boolean isForm(HttpServletRequest sr, RestRequestContext rrc) {
+	private boolean isForm(BearerTokenSupplier tokenSupplier) {
 		if (bearerTokenHeaderOnly) {
 			return false;
 		}
-		if (!"application/x-www-form-urlencoded".equals(sr.getContentType())) {
+		if (!"application/x-www-form-urlencoded".equals(tokenSupplier.getContentType())) {
 			return false;
 		}
-		if (rrc.methodType() == MethodType.GET) {//reject DELETE?
+		if (tokenSupplier.methodType() == MethodType.GET) {//reject DELETE?
 			return false;
 		}
 		return true;
 	}
 
-	private String tokenFromRequest(RequestContext req) {
+	private String tokenFromRequest(RequestContext req, BearerTokenSupplier tokenSupplier) {
 		String token = null;
-		HttpServletRequest sr = (HttpServletRequest) req.getAttribute(WebRequestConstants.SERVLET_REQUEST);
-		String authHeaderValue = sr.getHeader(HEADER_AUTHORIZATION);
+		String authHeaderValue = tokenSupplier.getAuthorizationHeaderValue();
 		if (authHeaderValue != null && authHeaderValue.regionMatches(true, 0, AUTH_SCHEME_BEARER + " ", 0, AUTH_SCHEME_BEARER.length() + 1)) {
 			token = authHeaderValue.substring(AUTH_SCHEME_BEARER.length() + 1)
 					.trim();
 			logger.debug("handle bearer token from HTTP header");
 		} else {
-			if (isForm(sr, (RestRequestContext) req)) {
+			if (isForm(tokenSupplier)) {
 				token = req.getParam(PARAM_ACCESS_TOKEN);
 				if (token != null) {
 					logger.debug("handle bearer token from body(form parameter)");
 				}
 			}
 		}
+
 		if (token != null && token.length() > 0) {
 			return token;
 		} else {
@@ -135,17 +131,17 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 	public AutoLoginInstruction handle(RequestContext req, boolean isLogined, UserContext user) {
 		if (isLogined) {
 			//WebAPIに限定
-			if (!(req instanceof RestRequestContext)) {
+			if (!(req instanceof BearerTokenSupplier)) {
 				return AutoLoginInstruction.ERROR;
 			}
 
 			//BearerTokenをサポートしているWebAPIに限定
-			RestRequestContext restReq = (RestRequestContext) req;
-			if (!restReq.supportBearerToken()) {
+			BearerTokenSupplier tokenSupplier = (BearerTokenSupplier) req;
+			if (!tokenSupplier.supportBearerToken()) {
 				return AutoLoginInstruction.ERROR;
 			}
 
-			String tokenStr = tokenFromRequest(req);
+			String tokenStr = tokenFromRequest(req, tokenSupplier);
 			if (tokenStr == null) {
 				return AutoLoginInstruction.THROUGH;
 			}
@@ -169,17 +165,17 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 
 			return AutoLoginInstruction.THROUGH;
 		} else {
-			if (!(req instanceof RestRequestContext)) {
+			if (!(req instanceof BearerTokenSupplier)) {
 				return AutoLoginInstruction.THROUGH;
 			}
 
 			//BearerTokenをサポートしているWebAPIに限定
-			RestRequestContext restReq = (RestRequestContext) req;
-			if (!restReq.supportBearerToken()) {
+			BearerTokenSupplier tokenSupplier = (BearerTokenSupplier) req;
+			if (!tokenSupplier.supportBearerToken()) {
 				return AutoLoginInstruction.THROUGH;
 			}
 
-			String tokenStr = tokenFromRequest(req);
+			String tokenStr = tokenFromRequest(req, tokenSupplier);
 			if (tokenStr == null) {
 				return AutoLoginInstruction.THROUGH;
 			}
@@ -202,7 +198,7 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 			//sessionにtokenを保存。
 			Session s = sessionService.getSession(false);
 			if (s != null) {
-				s.setAttribute(SESSION_ATTRIBUTE_BEARER_TOKEN, ((SimpleAuthTokenCredential) ali.getCredential()).getToken());
+				s.setAttribute(SESSION_ATTRIBUTE_BEARER_TOKEN, ((TokenCredential) ali.getCredential()).getToken());
 			}
 		}
 	}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
@@ -98,7 +98,8 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 		if (!"application/x-www-form-urlencoded".equals(tokenSupplier.getContentType())) {
 			return false;
 		}
-		if (tokenSupplier.methodType() == MethodType.GET) {//reject DELETE?
+		if (tokenSupplier.methodType() == null || tokenSupplier.methodType() == MethodType.GET) {//reject DELETE?
+			// null もしくは GET は、フォームパラメータを受け取ることができないため、フォームパラメータからのトークン取得は行わない。
 			return false;
 		}
 		return true;
@@ -188,6 +189,13 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 			}
 
 			Credential cre = authTokenHandler.toCredential(token);
+			if (!(cre instanceof TokenCredential)) {
+				// TokenCredential を実装していない Credential が返却された場合は、ログに警告を出す。
+				var clessName = (cre != null) ? cre.getClass()
+						.getName() : "null";
+				logger.warn("Created credential does not implement TokenCredential. class: {}.", clessName);
+			}
+
 			return new AutoLoginInstruction(cre);
 		}
 	}
@@ -197,8 +205,9 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 		if (!sessionService.isSessionStateless()) {
 			//sessionにtokenを保存。
 			Session s = sessionService.getSession(false);
-			if (s != null) {
-				s.setAttribute(SESSION_ATTRIBUTE_BEARER_TOKEN, ((TokenCredential) ali.getCredential()).getToken());
+			var credential = ali.getCredential();
+			if (s != null && credential instanceof TokenCredential tokenCredential) {
+				s.setAttribute(SESSION_ATTRIBUTE_BEARER_TOKEN, tokenCredential.getToken());
 			}
 		}
 	}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
@@ -46,6 +46,7 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 
 	private static Logger logger = LoggerFactory.getLogger(BearerTokenAutoLoginHandler.class);
 
+	@Deprecated(forRemoval = true, since = "4.1.0")
 	public static final String HEADER_AUTHORIZATION = "Authorization";
 	public static final String AUTH_SCHEME_BEARER = "Bearer";
 	public static final String PARAM_ACCESS_TOKEN = "access_token";
@@ -191,9 +192,11 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 			Credential cre = authTokenHandler.toCredential(token);
 			if (!(cre instanceof TokenCredential)) {
 				// TokenCredential を実装していない Credential が返却された場合は、ログに警告を出す。
-				var clessName = (cre != null) ? cre.getClass()
+				var className = (cre != null) ? cre.getClass()
 						.getName() : "null";
-				logger.warn("Created credential does not implement TokenCredential. class: {}.", clessName);
+				logger.warn(
+						"Created credential does not implement TokenCredential.  class: {}. If rejectAmbiguousRequest=true, the token verification will fail.",
+						className);
 			}
 
 			return new AutoLoginInstruction(cre);

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenAutoLoginHandler.java
@@ -169,7 +169,7 @@ public class BearerTokenAutoLoginHandler implements AutoLoginHandler {
 			} else {
 				AuthToken token = new AuthToken(tokenStr);
 				logger.warn("login session is avaliable, but another bearer token is specified. currentUser:" + user.getAccount()
-				.getUnmodifiableUniqueKey() + ", token:" + token.getType() + "." + token.getSeries() + "...");
+						.getUnmodifiableUniqueKey() + ", token:" + token.getType() + "." + token.getSeries() + "...");
 			}
 
 			return AutoLoginInstruction.THROUGH;

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenSupplier.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenSupplier.java
@@ -31,7 +31,7 @@ import org.iplass.mtp.webapi.definition.MethodType;
  */
 public interface BearerTokenSupplier {
 	/** Authorizationヘッダーのキー名 */
-	static final String HEADER_AUTHORIZATION = BearerTokenAutoLoginHandler.HEADER_AUTHORIZATION;
+	static final String HEADER_AUTHORIZATION = "Authorization";
 
 	/**
 	 * BearerTokenをサポートするかどうかを返します。

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenSupplier.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/authenticate/token/web/BearerTokenSupplier.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 DENTSU SOKEN INC. All Rights Reserved.
+ *
+ * Unless you have purchased a commercial license,
+ * the following license terms apply:
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.iplass.mtp.impl.auth.authenticate.token.web;
+
+import org.iplass.mtp.webapi.definition.MethodType;
+
+/**
+ * BearerToken提供インターフェース
+ * <p>
+ * {@link org.iplass.mtp.impl.auth.authenticate.token.web.BearerTokenAutoLoginHandler} で使用されるBearerTokenを提供するインターフェースです。<br>
+ * 本インターフェースは、{@link org.iplass.mtp.command.RequestContext} の派生クラスで、BearerTokenを用いた認証を利用するクラスに実装されることを想定しています。
+ * </p>
+ * @author SEKIGUCHI Naoya
+ */
+public interface BearerTokenSupplier {
+	/** Authorizationヘッダーのキー名 */
+	static final String HEADER_AUTHORIZATION = BearerTokenAutoLoginHandler.HEADER_AUTHORIZATION;
+
+	/**
+	 * BearerTokenをサポートするかどうかを返します。
+	 * @return BearerTokenをサポートする場合はtrue、そうでない場合はfalse
+	 */
+	boolean supportBearerToken();
+
+	/**
+	 * Authorization ヘッダーの値を提供します。
+	 * <p>
+	 * "Bearer {token}" の形式で提供されることが期待されます。
+	 * </p>
+	 * @return Authorization ヘッダーの値
+	 */
+	String getAuthorizationHeaderValue();
+
+	/**
+	 * HTTPリクエストのMethodTypeを返します
+	 * <p>
+	 * ヘッダーから認証情報を取得できない場合に、フォームからトークンの取得を試みる際の検証に使用します。<br>
+	 * ヘッダーからトークンを取得できることが保証されていれば、必ずしも実装する必要はありません。
+	 * </p>
+	 * @return HTTPリクエストのMethodType
+	 */
+	default MethodType methodType() {
+		return null;
+	}
+
+	/**
+	 * HTTPリクエストのContent-Typeを返します。
+	 * <p>
+	 * ヘッダーから認証情報を取得できない場合に、フォームからトークンの取得を試みる際の検証に使用します。<br>
+	 * ヘッダーからトークンを取得できることが保証されていれば、必ずしも実装する必要はありません。
+	 * </p>
+	 * @return HTTPリクエストのContent-Type
+	 */
+	default String getContentType() {
+		return null;
+	}
+}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/AccessTokenCredential.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/auth/oauth/AccessTokenCredential.java
@@ -1,19 +1,19 @@
 /*
  * Copyright (C) 2018 DENTSU SOKEN INC. All Rights Reserved.
- * 
+ *
  * Unless you have purchased a commercial license,
  * the following license terms apply:
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
@@ -23,15 +23,15 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.iplass.mtp.auth.login.Credential;
+import org.iplass.mtp.auth.login.TokenCredential;
 
 /**
  * OAuth2のアクセストークンを表現するCredential。
- * 
+ *
  * @author K.Higuchi
  *
  */
-public class AccessTokenCredential implements Credential, Serializable {
+public class AccessTokenCredential implements TokenCredential, Serializable {
 	//for internal use
 
 	private static final long serialVersionUID = -191370831048492625L;
@@ -57,6 +57,7 @@ public class AccessTokenCredential implements Credential, Serializable {
 		return id;
 	}
 
+	@Override
 	public String getToken() {
 		return token;
 	}
@@ -76,7 +77,7 @@ public class AccessTokenCredential implements Credential, Serializable {
 	@Override
 	public void setAuthenticationFactor(String name, Object value) {
 		if (additionalAuthenticationFactor == null) {
-			additionalAuthenticationFactor = new HashMap<String, Object>();
+			additionalAuthenticationFactor = new HashMap<>();
 		}
 		additionalAuthenticationFactor.put(name, value);
 	}

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestRequestContext.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestRequestContext.java
@@ -19,11 +19,6 @@
  */
 package org.iplass.mtp.impl.webapi.rest;
 
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.core.Request;
-
 import org.iplass.mtp.impl.auth.authenticate.token.web.BearerTokenSupplier;
 import org.iplass.mtp.impl.web.WebRequestContext;
 import org.iplass.mtp.impl.web.WebRequestStack;
@@ -31,6 +26,11 @@ import org.iplass.mtp.web.WebRequestConstants;
 import org.iplass.mtp.webapi.WebApiRequestConstants;
 import org.iplass.mtp.webapi.definition.MethodType;
 import org.iplass.mtp.webapi.definition.RequestType;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Request;
 
 public class RestRequestContext extends WebRequestContext implements BearerTokenSupplier {
 	static final String WEB_API_RUNTIME_NAME = "mtp.restRequestContext.webApiRuntime";;

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestRequestContext.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestRequestContext.java
@@ -19,6 +19,7 @@
  */
 package org.iplass.mtp.impl.webapi.rest;
 
+import org.iplass.mtp.impl.auth.authenticate.token.web.BearerTokenSupplier;
 import org.iplass.mtp.impl.web.WebRequestContext;
 import org.iplass.mtp.impl.web.WebRequestStack;
 import org.iplass.mtp.web.WebRequestConstants;
@@ -31,7 +32,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Request;
 
-public class RestRequestContext extends WebRequestContext {
+public class RestRequestContext extends WebRequestContext implements BearerTokenSupplier {
 	static final String WEB_API_RUNTIME_NAME = "mtp.restRequestContext.webApiRuntime";;
 	static final String MAX_BODY_SIZE = "mtp.restRequestContext.maxBodySize";;
 
@@ -69,6 +70,7 @@ public class RestRequestContext extends WebRequestContext {
 		this.requestType = requestType;
 	}
 
+	@Override
 	public boolean supportBearerToken() {
 		return supportBearerToken;
 	}
@@ -77,6 +79,7 @@ public class RestRequestContext extends WebRequestContext {
 		return rsRequest;
 	}
 
+	@Override
 	public MethodType methodType() {
 		return methodType;
 	}
@@ -125,5 +128,27 @@ public class RestRequestContext extends WebRequestContext {
 		default:
 			super.setAttribute(name, value);
 		}
+	}
+
+	@Override
+	public String getAuthorizationHeaderValue() {
+		var servletRequest = getServletRequest();
+		var headerNames = servletRequest.getHeaderNames();
+		while (headerNames.hasMoreElements()) {
+			String headerName = headerNames.nextElement();
+			if (HEADER_AUTHORIZATION.equalsIgnoreCase(headerName)) {
+				return servletRequest.getHeader(headerName);
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public String getContentType() {
+		return getServletRequest().getContentType();
+	}
+
+	private HttpServletRequest getServletRequest() {
+		return (HttpServletRequest) getAttribute(WebRequestConstants.SERVLET_REQUEST);
 	}
 }

--- a/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestRequestContext.java
+++ b/iplass-web/src/main/java/org/iplass/mtp/impl/webapi/rest/RestRequestContext.java
@@ -19,6 +19,11 @@
  */
 package org.iplass.mtp.impl.webapi.rest;
 
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.core.Request;
+
 import org.iplass.mtp.impl.auth.authenticate.token.web.BearerTokenSupplier;
 import org.iplass.mtp.impl.web.WebRequestContext;
 import org.iplass.mtp.impl.web.WebRequestStack;
@@ -26,11 +31,6 @@ import org.iplass.mtp.web.WebRequestConstants;
 import org.iplass.mtp.webapi.WebApiRequestConstants;
 import org.iplass.mtp.webapi.definition.MethodType;
 import org.iplass.mtp.webapi.definition.RequestType;
-
-import jakarta.servlet.ServletContext;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.core.Request;
 
 public class RestRequestContext extends WebRequestContext implements BearerTokenSupplier {
 	static final String WEB_API_RUNTIME_NAME = "mtp.restRequestContext.webApiRuntime";;
@@ -132,15 +132,7 @@ public class RestRequestContext extends WebRequestContext implements BearerToken
 
 	@Override
 	public String getAuthorizationHeaderValue() {
-		var servletRequest = getServletRequest();
-		var headerNames = servletRequest.getHeaderNames();
-		while (headerNames.hasMoreElements()) {
-			String headerName = headerNames.nextElement();
-			if (HEADER_AUTHORIZATION.equalsIgnoreCase(headerName)) {
-				return servletRequest.getHeader(headerName);
-			}
-		}
-		return null;
+		return getServletRequest().getHeader(HEADER_AUTHORIZATION);
 	}
 
 	@Override


### PR DESCRIPTION
closes #2087 

<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
- BearerToken を取得できる処理を BearerTokenSupplier を実装している RequestContext に拡張
- TokenCredential を追加し、トークン認証クラスに実装

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
- WebAPIの実行確認
   - 個人アクセストークンを利用した実行確認（SAT パターン）
   - OAuth アクセストークンを利用した実行確認（OAT パターン）

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
- 追加で BearerToken 取得後の成功処理時にキャストする型をインターフェースに変更しました。