### PR TITLE
JasperReports 6.21.3 -> 7.0.7 バージョンアップ xml-apis 除外

### DIFF
--- a/iplass-web/libs.gradle
+++ b/iplass-web/libs.gradle
@@ -2,11 +2,9 @@ configurations {
 	compileOnly.extendsFrom(jeecoreapis)
 	compileOnly.extendsFrom(jeewebapis)
 
-	api {
-		// JasperReports 7 系の推移依存で xml-apis が含まれるが、JDK に含まれており種類によっては動作不良を起こすため除外する
-		// corretto21 jdk では動作不良を起こすことを確認した。
-		exclude group: 'xml-apis', module: 'xml-apis' 
-	}
+	// JasperReports 7 系の推移依存で xml-apis が含まれるが、JDK に含まれており種類によっては動作不良を起こすため除外する
+	// corretto21 jdk では動作不良を起こすことを確認した。
+	all*.exclude group: 'xml-apis', module: 'xml-apis' 
 }
 
 dependencies {

--- a/iplass-web/libs.gradle
+++ b/iplass-web/libs.gradle
@@ -2,8 +2,7 @@ configurations {
 	compileOnly.extendsFrom(jeecoreapis)
 	compileOnly.extendsFrom(jeewebapis)
 
-	// JasperReports 7 系の推移依存で xml-apis が含まれるが、JDK に含まれており種類によっては動作不良を起こすため除外する
-	// corretto21 jdk では動作不良を起こすことを確認した。
+	// JasperReports 7 系の推移依存で xml-apis が含まれるが、JDK に含まれており動作不良を起こすため除外する
 	all*.exclude group: 'xml-apis', module: 'xml-apis' 
 }
 

--- a/iplass-web/libs.gradle
+++ b/iplass-web/libs.gradle
@@ -1,6 +1,12 @@
 configurations {
 	compileOnly.extendsFrom(jeecoreapis)
 	compileOnly.extendsFrom(jeewebapis)
+
+	api {
+		// JasperReports 7 系の推移依存で xml-apis が含まれるが、JDK に含まれており種類によっては動作不良を起こすため除外する
+		// corretto21 jdk では動作不良を起こすことを確認した。
+		exclude group: 'xml-apis', module: 'xml-apis' 
+	}
 }
 
 dependencies {


### PR DESCRIPTION
closes #2127 

xml-apis が含まれていると、以下のようなエラーが発生する可能性があります。

<details>
<summary>error stacktrace...</summary>

java.lang.NoClassDefFoundError: SAXParserFactory
  at java.base/java.lang.Class.getDeclaredFields0(Native Method)
  at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3475)
  at java.base/java.lang.Class.getDeclaredFields(Class.java:2544)
  at org.glassfish.jersey.internal.util.ReflectionHelper$4.run(ReflectionHelper.java:290)
  at org.glassfish.jersey.internal.util.ReflectionHelper$4.run(ReflectionHelper.java:287)
  at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
  at org.glassfish.jersey.server.model.IntrospectionModeller.checkResourceClassFields(IntrospectionModeller.java:204)
  at org.glassfish.jersey.server.model.IntrospectionModeller.doCreateResourceBuilder(IntrospectionModeller.java:118)
  at org.glassfish.jersey.server.model.IntrospectionModeller$1.call(IntrospectionModeller.java:91)
  at org.glassfish.jersey.server.model.IntrospectionModeller$1.call(IntrospectionModeller.java:88)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
  at org.glassfish.jersey.internal.Errors.processWithException(Errors.java:232)
  at org.glassfish.jersey.server.model.IntrospectionModeller.createResourceBuilder(IntrospectionModeller.java:88)
  at org.glassfish.jersey.server.model.Resource.from(Resource.java:781)
  at org.glassfish.jersey.server.ResourceBagConfigurator.init(ResourceBagConfigurator.java:55)
  at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:347)
  at org.glassfish.jersey.server.ApplicationHandler.lambda$initialize$1(ApplicationHandler.java:309)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
  at org.glassfish.jersey.internal.Errors.processWithException(Errors.java:232)
  at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:308)
  at org.glassfish.jersey.server.ApplicationHandler.<init>(ApplicationHandler.java:273)
  at org.glassfish.jersey.servlet.WebComponent.<init>(WebComponent.java:311)
  at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:154)
  at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:339)
  at jakarta.servlet.GenericServlet.init(GenericServlet.java:143)
  at jakarta.servlet.http.HttpServlet.init(HttpServlet.java:121)
  at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:840)
  at org.apache.catalina.core.StandardWrapper.loadServlet(StandardWrapper.java:797)
  at org.apache.catalina.core.StandardWrapper.allocate(StandardWrapper.java:578)
  at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:589)
  at org.apache.catalina.core.ApplicationDispatcher.processRequest(ApplicationDispatcher.java:392)
  at org.apache.catalina.core.ApplicationDispatcher.doForward(ApplicationDispatcher.java:321)
  at org.apache.catalina.core.ApplicationDispatcher.forward(ApplicationDispatcher.java:266)
  at org.iplass.mtp.impl.web.DispatcherFilter.doFilter(DispatcherFilter.java:151)
  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
  at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:165)
  at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:88)
  at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:492)
  at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:113)
  at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:83)
  at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:654)
  at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:72)
  at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
  at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399)
  at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
  at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903)
  at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1775)
  at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
  at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:973)
  at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:491)
  at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
  at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ClassNotFoundException: SAXParserFactory
  at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1377)
  at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1186)
  ... 55 more

6月 19, 2026 2:12:37 午後 org.apache.catalina.core.ApplicationDispatcher invoke
重大: サーブレット [Jersey REST Service] に例外を割り当てます
java.lang.ClassNotFoundException: SAXParserFactory
  at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1377)
  at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1186)
  at java.base/java.lang.Class.getDeclaredFields0(Native Method)
  at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3475)
  at java.base/java.lang.Class.getDeclaredFields(Class.java:2544)
  at org.glassfish.jersey.internal.util.ReflectionHelper$4.run(ReflectionHelper.java:290)
  at org.glassfish.jersey.internal.util.ReflectionHelper$4.run(ReflectionHelper.java:287)
  at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
  at org.glassfish.jersey.server.model.IntrospectionModeller.checkResourceClassFields(IntrospectionModeller.java:204)
  at org.glassfish.jersey.server.model.IntrospectionModeller.doCreateResourceBuilder(IntrospectionModeller.java:118)
  at org.glassfish.jersey.server.model.IntrospectionModeller$1.call(IntrospectionModeller.java:91)
  at org.glassfish.jersey.server.model.IntrospectionModeller$1.call(IntrospectionModeller.java:88)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
  at org.glassfish.jersey.internal.Errors.processWithException(Errors.java:232)
  at org.glassfish.jersey.server.model.IntrospectionModeller.createResourceBuilder(IntrospectionModeller.java:88)
  at org.glassfish.jersey.server.model.Resource.from(Resource.java:781)
  at org.glassfish.jersey.server.ResourceBagConfigurator.init(ResourceBagConfigurator.java:55)
  at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:347)
  at org.glassfish.jersey.server.ApplicationHandler.lambda$initialize$1(ApplicationHandler.java:309)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
  at org.glassfish.jersey.internal.Errors.processWithException(Errors.java:232)
  at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:308)
  at org.glassfish.jersey.server.ApplicationHandler.<init>(ApplicationHandler.java:273)
  at org.glassfish.jersey.servlet.WebComponent.<init>(WebComponent.java:311)
  at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:154)
  at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:339)
  at jakarta.servlet.GenericServlet.init(GenericServlet.java:143)
  at jakarta.servlet.http.HttpServlet.init(HttpServlet.java:121)
  at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:840)
  at org.apache.catalina.core.StandardWrapper.loadServlet(StandardWrapper.java:797)
  at org.apache.catalina.core.Stand14:12:37.608 [http-nio-8080-exec-10] DEBUG 172    o.i.mtp.impl.core.ExecuteContext - finalize execute context:org.iplass.mtp.impl.core.ExecuteContext@6fc2036a
14:12:37.608 [http-nio-8080-exec-10] ERROR     o.i.mtp.impl.web.DispatcherFilter - Exception occurred while processing URI:/mtp/testTanakaEE/api/gem/spreadsheet/data サーブレット [Jersey REST Service] のServlet.init()が例外を投げました
jakarta.servlet.ServletException: サーブレット [Jersey REST Service] のServlet.init()が例外を投げました
  at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:856)
  at org.apache.catalina.core.StandardWrapper.loadServlet(StandardWrapper.java:797)
  at org.apache.catalina.core.StandardWrapper.allocate(StandardWrapper.java:578)
  at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:589)
  at org.apache.catalina.core.ApplicationDispatcher.processRequest(ApplicationDispatcher.java:392)
  at org.apache.catalina.core.ApplicationDispatcher.doForward(ApplicationDispatcher.java:321)
  at org.apache.catalina.core.ApplicationDispatcher.forward(ApplicationDispatcher.java:266)
  at org.iplass.mtp.impl.web.DispatcherFilter.doFilter(DispatcherFilter.java:151)
  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
  at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:165)
  at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:88)
  at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:492)
  at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:113)
  at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:83)
  at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:654)
  at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:72)
  at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
  at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399)
  at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
  at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903)
  at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1775)
  at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
  at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:973)
  at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:491)
  at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
  at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.NoClassDefFoundError: SAXParserFactory
  at java.base/java.lang.Class.getDeclaredFields0(Native Method)
  at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3475)
  at java.base/java.lang.Class.getDeclaredFields(Class.java:2544)
  at org.glassfish.jersey.internal.util.ReflectionHelper$4.run(ReflectionHelper.java:290)
  at org.glassfish.jersey.internal.util.ReflectionHelper$4.run(ReflectionHelper.java:287)
  at java.base/java.security.AccessController.doPrivileged(AccessController.java:319)
  at org.glassfish.jersey.server.model.IntrospectionModeller.checkResourceClassFields(IntrospectionModeller.java:204)
  at org.glassfish.jersey.server.model.IntrospectionModeller.doCreateResourceBuilder(IntrospectionModeller.java:118)
  at org.glassfish.jersey.server.model.IntrospectionModeller$1.call(IntrospectionModeller.java:91)
  at org.glassfish.jersey.server.model.IntrospectionModeller$1.call(IntrospectionModeller.java:88)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
  at org.glassfish.jersey.internal.Errors.processWithException(Errors.java:232)
  at org.glassfish.jersey.server.model.IntrospectionModeller.createResourceBuilder(IntrospectionModeller.java:88)
  at org.glassfish.jersey.server.model.Resource.from(Resource.java:781)
  at org.glassfish.jersey.server.ResourceBagConfigurator.init(ResourceBagConfigurator.java:55)
  at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:347)
  at org.glassfish.jersey.server.ApplicationHandler.lambda$initialize$1(ApplicationHandler.java:309)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
  at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
  at org.glassfish.jersey.internal.Errors.processWithException(Errors.java:232)
  at org.glassfish.jersey.server.ApplicationHandler.initialize(ApplicationHandler.java:308)
  at org.glassfish.jersey.server.ApplicationHandler.<init>(ApplicationHandler.java:273)
  at org.glassfish.jersey.servlet.WebComponent.<init>(WebComponent.java:311)
  at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:154)
  at org.glassfish.jersey.servlet.ServletContainer.init(ServletContainer.java:339)
  at jakarta.servlet.GenericServlet.init(GenericServlet.java:143)
  at jakarta.servlet.http.HttpServlet.init(HttpServlet.java:121)
  at org.apache.catalina.core.StandardWrapper.initServlet(StandardWrapper.java:840)
  ... 26 common frames omitted
Caused by: java.lang.ClassNotFoundException: SAXParserFactory
  at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1377)
  at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1186)
  ... 55 common frames omitted
ardWrapper.allocate(StandardWrapper.java:578)
  at org.apache.catalina.core.ApplicationDispatcher.invoke(ApplicationDispatcher.java:589)
  at org.apache.catalina.core.ApplicationDispatcher.processRequest(ApplicationDispatcher.java:392)
  at org.apache.catalina.core.ApplicationDispatcher.doForward(ApplicationDispatcher.java:321)
  at org.apache.catalina.core.ApplicationDispatcher.forward(ApplicationDispatcher.java:266)
  at org.iplass.mtp.impl.web.DispatcherFilter.doFilter(DispatcherFilter.java:151)
  at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:162)
  at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:138)
  at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:165)
  at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:88)
  at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:492)
  at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:113)
  at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:83)
  at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:654)
  at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:72)
  at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:342)
  at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:399)
  at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63)
  at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:903)
  at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1775)
  at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52)
  at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:973)
  at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:491)
  at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:63)
  at java.base/java.lang.Thread.run(Thread.java:1583)

</details>

<!--
タイトルには、変更点の概要を記述してください。
コミットメッセージとして使用されるため、タイトルは簡潔で短く、説明的なものにしてください。
厳格な命名規則は定めませんが、対応内容が特定のモジュールや機能に限定される場合には、モジュール名や機能名を見出しとして先頭に付けることを推奨します。
-->

## 対応内容
<!--
対応内容を簡潔に記述してください。
Issueを解決するPRである場合には、Issueへのリンクを張ってください。masterブランチにマージされた際に自動的にIssueがクローズされます。
例: closes #123 または fixes #123
-->
- net.sf.jasperreports:jasperreports 7.0.7 から推移依存する xml-apis を除外する
- 除外理由
    - JDK で xml-apis が含まれている状態だと REST API 実行時にエラーが発生する環境がある
    - JDK 21 では javax.xml パッケージが標準で含まれているため、xml-apis は不要

## 動作確認・スクリーンショット（任意）
<!--
動作確認した内容を簡潔に記述してください。
画面の新規実装や修正を行った場合には、スクリーンショットがあるとわかりやすいです。
-->
- 標準エンティティの動作確認（検索・更新・登録・削除）
- JasperReports出力確認（PDF, EXCEL）

動作確認に使用したJDK

temurin
```
openjdk version "21.0.11" 2026-04-21 LTS
OpenJDK Runtime Environment Temurin-21.0.11+10 (build 21.0.11+10-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.11+10 (build 21.0.11+10-LTS, mixed mode, sharing)
```

corretto
```
openjdk 21.0.10 2026-01-20 LTS
OpenJDK Runtime Environment Corretto-21.0.10.7.1 (build 21.0.10+7-LTS)
OpenJDK 64-Bit Server VM Corretto-21.0.10.7.1 (build 21.0.10+7-LTS, mixed mode, sharing)
```

## レビュー観点・補足情報（任意）
<!--
特に注視して確認してほしい点や、補足情報があれば記述してください。
-->
- バージョンアップした機能とは関係ない箇所でエラーが発生したため、エラー解消を目的とした修正となります。
- 同様の症例が [stackoverflow](https://stackoverflow.com/questions/58226222/xml-api-jar-and-org-xml-sax-classes-having-issues-with-java-11) に記載がありました。