### PR TITLE
GEM : 検索結果TABLEの高さ設定時、縦スクロールバー表示でヘッダー行とデータ行の列がずれるの対応 (4.0)

### DIFF
--- a/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/SearchResultSection.jsp
+++ b/iplass-gem/src/main/resources/META-INF/resources/jsp/gem/generic/element/section/SearchResultSection.jsp
@@ -735,6 +735,15 @@ function setData(list, count) {
 		grid.addRowData(index + 1, this);
 	});
 
+<%
+	if (section.getDispHeight() > 0) {
+%>
+	//データ描画後に幅を再計算してjqGridにスクロールバー幅を確保させる(列幅・横スクロールは保持)。
+	grid.jqGrid("setGridWidth", $("#gbox_searchResult").width(), false);
+<%
+	}
+%>
+
 	if ($("audio, video").length > 0) {
 		$('audio, video').mediaelementplayer({
 			success: function(player, node) {


### PR DESCRIPTION
## 対応内容
4.1版の修正を4.0に反映
#2079
closes #2153 

## 動作確認・スクリーンショット（任意）
検索結果TABLEの高さ設定を行い、検索結果に縦スクロールバーがあるときに右にスクロールしてもヘッダーとデータ列がずれないことを確認
ページ移動後の表示を確認
別Entityからの選択ダイアログ時の表示でも問題ないことを確認

## レビュー観点・補足情報（任意）
